### PR TITLE
blog: Loi sur l'aide à mourir : tout comprendre et les positions des candidats 2027

### DIFF
--- a/app-tanstack/src/content/articles.ts
+++ b/app-tanstack/src/content/articles.ts
@@ -807,4 +807,135 @@ export const articles: Article[] = [
       ],
     },
   },
+  {
+    slug: 'loi-aide-a-mourir-france-candidats-2027',
+    title: `Loi sur l'aide à mourir : tout comprendre et les positions des ${candidatesCount} candidats à la présidentielle 2027`,
+    excerpt:
+      "Après trois ans de navette parlementaire, l'Assemblée nationale a définitivement adopté le droit à l'aide à mourir le 15 juillet 2026. Que contient la loi, pourquoi divise-t-elle, et où se situent les candidats à la présidentielle 2027 ?",
+    date: '2026-07-18',
+    tag: 'Analyse',
+    content: `
+<p>Trois lectures rejetées par le Sénat, une commission mixte paritaire sans accord, un ultime « dernier mot » donné à l'Assemblée nationale, et enfin une double saisine du Conseil constitutionnel : le <strong>15 juillet 2026</strong>, la France a définitivement légalisé l'aide à mourir. Voici ce que contient la loi, pourquoi elle continue de diviser, et les positions des ${candidatesCount} candidats à la présidentielle 2027.</p>
+
+<h2>Que change la loi sur l'aide à mourir ?</h2>
+<p>Le texte crée un <strong>droit à l'aide à mourir</strong>, distinct du cadre existant de sédation profonde et continue jusqu'au décès. Pour y avoir accès, une personne doit cumuler plusieurs conditions strictes :</p>
+<ul>
+<li>Être atteinte d'une <strong>affection grave et incurable</strong> engageant le pronostic vital, en phase avancée ou terminale ;</li>
+<li>Présenter une <strong>souffrance physique ou psychologique réfractaire</strong> aux traitements, ou jugée insupportable par la personne lorsqu'elle a choisi de ne pas ou plus être traitée ;</li>
+<li>Être en capacité d'exprimer sa volonté de façon <strong>libre et éclairée</strong>.</li>
+</ul>
+<p>Le texte instaure une <strong>clause de conscience</strong> pour les professionnels de santé impliqués dans l'examen des demandes ou l'administration de la substance létale : ceux qui refusent doivent orienter le patient vers un autre médecin. Les <strong>pharmaciens</strong>, en revanche, n'y sont pas soumis. Un <strong>délit d'entrave</strong> est créé, avec des sanctions doublées par rapport au texte initial, pour punir les actions visant à empêcher l'accès à l'aide à mourir ou à l'information sur ce droit.</p>
+<p>Ce texte est le second volet d'un diptyque légis­latif : la loi garantissant l'égal accès aux soins palliatifs, promulguée dès le <strong>26 mai 2026</strong>, avait fait l'objet d'un consensus bien plus large. C'est bien le volet « aide à mourir » qui a cristallisé les tensions.</p>
+
+<h2>Une navette parlementaire de plus de trois ans</h2>
+<ul>
+<li><strong>Mai 2025</strong> : l'Assemblée nationale adopte en première lecture les deux propositions de loi (soins palliatifs et aide à mourir).</li>
+<li><strong>28 janvier 2026</strong> : le Sénat, où siège une majorité de droite, rejette le texte sur l'aide à mourir en première lecture (181 voix contre, 122 pour).</li>
+<li><strong>25 février 2026</strong> : l'Assemblée nationale adopte un texte modifié en deuxième lecture et le retransmet au Sénat.</li>
+<li><strong>12 mai 2026</strong> : le Sénat rejette à nouveau le texte en séance plénière.</li>
+<li><strong>26 mai 2026</strong> : la loi sur les soins palliatifs, elle, est promulguée (loi n° 2026-404).</li>
+<li><strong>2 juin 2026</strong> : la commission mixte paritaire (7 députés, 7 sénateurs) échoue à trouver un accord sur l'aide à mourir.</li>
+<li><strong>30 juin 2026</strong> : l'Assemblée nationale adopte à nouveau le texte en nouvelle lecture (295 voix pour, 232 contre).</li>
+<li><strong>14 juillet 2026</strong> : le Premier ministre Sébastien Lecornu annonce qu'il saisira le Conseil constitutionnel dès l'adoption définitive.</li>
+<li><strong>15 juillet 2026</strong> : dans le cadre de la procédure du « dernier mot » donné à l'Assemblée, les députés adoptent définitivement le texte par <strong>291 voix pour, 241 contre et 29 abstentions</strong>.</li>
+<li><strong>16 juillet 2026</strong> : le président du Sénat Gérard Larcher saisit à son tour le Conseil constitutionnel.</li>
+</ul>
+
+<h2>Pourquoi cette loi divise la France</h2>
+
+<h3>1. Dignité individuelle contre sacralité de la vie</h3>
+<p>Pour les partisans du texte, mourir dans la dignité et choisir le moment de sa mort relève d'une liberté individuelle fondamentale, en particulier pour des malades en fin de vie soumis à des souffrances jugées insupportables. Pour les opposants, la vie ne se négocie pas, et la médecine ne doit jamais avoir pour but de donner la mort — le cadre existant de sédation profonde et continue leur paraît suffisant.</p>
+
+<h3>2. Le rôle des soignants</h3>
+<p>La clause de conscience individuelle fait consensus, mais son absence pour les <strong>établissements</strong> de santé (une clinique ou un EHPAD ne peut refuser collectivement de pratiquer l'acte) inquiète une partie des professionnels et des opposants, qui y voient une obligation imposée à des structures parfois confessionnelles ou engagées dans les soins palliatifs.</p>
+
+<h3>3. Le délai de réflexion, au cœur de la saisine du Conseil constitutionnel</h3>
+<p>Le texte prévoit un délai d'au moins deux jours entre la notification de la décision du médecin et la confirmation de la demande par le patient. Les opposants, dont le Premier ministre lui-même dans sa saisine, jugent ce délai trop court pour garantir un consentement <strong>libre, éclairé et persistant</strong> — en particulier pour les <strong>majeurs protégés</strong> (sous tutelle ou curatelle), un point spécifiquement soulevé devant le Conseil constitutionnel.</p>
+
+<h3>4. Un accès aux soins palliatifs encore inégal</h3>
+<p>Une partie des critiques ne porte pas sur le principe de l'aide à mourir mais sur son séquençage : plusieurs départements restent dépourvus d'unités de soins palliatifs, ce qui fait craindre qu'un droit à mourir soit ouvert avant qu'un vrai droit à être soigné et accompagné jusqu'au bout ne soit garanti partout sur le territoire.</p>
+
+<h2>Le Conseil constitutionnel, dernière étape avant la promulgation</h2>
+<p>La loi n'est pas encore promulguée : elle est actuellement examinée par le <strong>Conseil constitutionnel</strong>, saisi à la fois par le Premier ministre Sébastien Lecornu (14 juillet) et par le président du Sénat Gérard Larcher (16 juillet), rejoints par des sénateurs de la majorité sénatoriale de droite. Les saisines portent notamment sur la brièveté du délai de rétractation, la situation des majeurs protégés et l'absence de clause de conscience pour les établissements. Le Conseil peut valider le texte, le censurer partiellement, ou le renvoyer avec des réserves d'interprétation.</p>
+
+<h2>Les positions des ${candidatesCount} candidats à la présidentielle 2027</h2>
+<p>Sur la question <a href="/question-politique/euthanasie-loi-france">« Que pensez-vous de la fin de vie et de l'euthanasie ? »</a> du Quizz du Berger, les ${candidatesCount} candidats se répartissent en trois familles. Fait notable : <strong>aucun</strong> ne rejette catégoriquement toute évolution du droit existant — l'option la plus restrictive du quiz (« la vie est sacrée, on ne doit jamais aider quelqu'un à mourir ») ne recueille aucune réponse.</p>
+
+<h3>Famille 1 — Le cadre actuel (sédation profonde) leur paraît suffisant</h3>
+<p>Ces candidats jugent que la loi de 2016 sur la sédation profonde et continue répond déjà à l'essentiel des situations de fin de vie, et se sont opposés ou montrés très réservés sur le nouveau texte.</p>
+<ul>
+<li><a href="/candidat/marine-le-pen">Marine Le Pen</a> (RN) — Le groupe RN a voté quasi unanimement contre le texte le 15 juillet (12 voix pour sur les bancs du groupe, la grande majorité contre) ; priorité donnée au développement des soins palliatifs plutôt qu'à l'aide à mourir.</li>
+<li><a href="/candidat/eric-zemmour">Éric Zemmour</a> (Reconquête) — Opposition de principe, met en avant le risque de dérive vers une « euthanasie de confort ».</li>
+<li><a href="/candidat/laurent-wauquiez">Laurent Wauquiez</a> (LR) — Président du groupe Droite Républicaine à l'Assemblée, dont les députés ont voté très majoritairement contre le texte (41 contre, 5 pour).</li>
+<li><a href="/candidat/bruno-retailleau">Bruno Retailleau</a> (LR) — Ligne conservatrice sur les questions de société, proche de la majorité sénatoriale de droite qui a rejeté le texte à trois reprises.</li>
+<li><a href="/candidat/xavier-bertrand">Xavier Bertrand</a> — Prudence assumée sur la fin de vie, priorité aux soins palliatifs avant toute nouvelle étape.</li>
+<li><a href="/candidat/nicolas-dupont-aignan">Nicolas Dupont-Aignan</a> (DLF) — Opposition au nom de la protection des personnes les plus vulnérables.</li>
+<li><a href="/candidat/david-lisnard">David Lisnard</a> — Réserve sur l'aide à mourir, insiste sur le développement préalable des soins palliatifs.</li>
+<li><a href="/candidat/francois-bayrou">François Bayrou</a> (MoDem) — Le groupe MoDem s'est divisé au moment du vote (20 pour, 16 contre) ; ligne personnelle marquée par la prudence.</li>
+<li><a href="/candidat/gerald-darmanin">Gérald Darmanin</a> — Position prudente, proche de la ligne défendue par la majorité sénatoriale de droite.</li>
+</ul>
+
+<h3>Famille 2 — Favorables à une légalisation strictement encadrée : la ligne du texte adopté</h3>
+<p>Ces candidats défendent une aide à mourir ouverte, mais assortie de conditions médicales strictes — la ligne qui correspond le plus directement au texte définitivement adopté le 15 juillet.</p>
+<ul>
+<li><a href="/candidat/gabriel-attal">Gabriel Attal</a> (Renaissance) — Le groupe Ensemble pour la République a voté majoritairement pour (64 pour, 18 contre, 9 abstentions) ; soutien à une aide à mourir strictement encadrée.</li>
+<li><a href="/candidat/edouard-philippe">Édouard Philippe</a> (Horizons) — Le groupe Horizons s'est divisé (16 pour, 18 contre) ; position personnelle favorable à un encadrement strict des conditions d'accès.</li>
+<li><a href="/candidat/raphael-glucksmann">Raphaël Glucksmann</a> (Place Publique) — Soutien à un droit à mourir dans la dignité, sous conditions médicales strictes.</li>
+<li><a href="/candidat/jerome-guedj">Jérôme Guedj</a> (PS) — Le groupe Socialistes a très largement voté pour (60 pour, 4 contre) ; ligne social-démocrate classique sur la fin de vie.</li>
+<li><a href="/candidat/francois-hollande">François Hollande</a> — Avait porté le débat sur la fin de vie sous ses deux mandats ; favorable à une évolution encadrée du droit existant.</li>
+<li><a href="/candidat/bernard-cazeneuve">Bernard Cazeneuve</a> — Soutien à un texte équilibré entre liberté individuelle et protection des personnes fragiles.</li>
+<li><a href="/candidat/marine-tondelier">Marine Tondelier</a> (Les Écologistes) — Le groupe Écologiste et Social a voté à une large majorité pour (35 pour, 1 contre) ; défend un droit à mourir dans la dignité couplé à un accès réel aux soins palliatifs partout sur le territoire.</li>
+<li><a href="/candidat/francois-ruffin">François Ruffin</a> — Soutien à une aide à mourir encadrée, à condition que les soins palliatifs soient renforcés en parallèle.</li>
+<li><a href="/candidat/fabien-roussel">Fabien Roussel</a> (PCF) — Le groupe GDR a majoritairement voté pour (11 pour, 2 contre) ; soutien à une légalisation encadrée.</li>
+<li><a href="/candidat/dominique-de-villepin">Dominique de Villepin</a> — Plaide pour un encadrement strict, prudent sur les dérives possibles.</li>
+<li><a href="/candidat/francois-asselineau">François Asselineau</a> (UPR) — Soutien à une légalisation encadrée de l'aide à mourir, indépendamment de ses positions souverainistes sur d'autres sujets.</li>
+<li><a href="/candidat/patrick-sebastien">Patrick Sébastien</a> — Soutien de principe à une aide à mourir encadrée.</li>
+</ul>
+
+<h3>Famille 3 — Pour un droit fondamental, plus large que le texte adopté</h3>
+<p>Ces candidats jugent que le texte définitivement adopté reste trop restrictif et défendent un droit plus étendu, incluant l'euthanasie et le suicide assisté sans les mêmes limites de pronostic vital.</p>
+<ul>
+<li><a href="/candidat/jean-luc-melenchon">Jean-Luc Mélenchon</a> (LFI) — Le groupe LFI a majoritairement voté pour le texte le 15 juillet, mais défend une conception plus large : mourir dans la dignité comme liberté individuelle pleine et entière.</li>
+<li><a href="/candidat/clementine-autain">Clémentine Autain</a> — Défend le libre choix jusqu'au bout, sur une ligne féministe et libertaire.</li>
+<li><a href="/candidat/nathalie-arthaud">Nathalie Arthaud</a> (LO) — Soutien à un droit plein et entier à mourir dans la dignité.</li>
+<li><a href="/candidat/delphine-batho">Delphine Batho</a> (Génération Écologie) — Défend une loi allant au-delà du texte adopté, jugé encore trop restrictif dans ses conditions d'accès.</li>
+<li><a href="/candidat/juan-branco">Juan Branco</a> — Défend une liberté individuelle totale face à la fin de vie.</li>
+</ul>
+
+<h2>Arguments pour et arguments contre la loi sur l'aide à mourir</h2>
+<table>
+<tr><th>Arguments en faveur du texte</th><th>Arguments contre le texte</th></tr>
+<tr><td>Reconnaît un droit à disposer de sa fin de vie pour des malades en phase avancée ou terminale.</td><td>La vie humaine ne devrait jamais être abrégée par la médecine, quelles que soient les conditions.</td></tr>
+<tr><td>Conditions médicales strictes (pronostic vital engagé, souffrance réfractaire) censées prévenir les dérives.</td><td>Le délai de réflexion de deux jours est jugé trop court pour un consentement vraiment libre et persistant.</td></tr>
+<tr><td>Clause de conscience individuelle qui protège les soignants opposés à l'acte.</td><td>Absence de clause de conscience pour les établissements, qui ne peuvent refuser collectivement de pratiquer l'acte.</td></tr>
+<tr><td>Fruit de plus de trois ans de débat parlementaire et de deux lectures au Sénat.</td><td>Le Sénat a rejeté le texte à trois reprises ; son adoption repose sur le « dernier mot » donné à l'Assemblée.</td></tr>
+<tr><td>Accompagné d'une loi sur les soins palliatifs, déjà promulguée en mai 2026.</td><td>L'accès aux soins palliatifs reste inégal sur le territoire, ce qui fragilise la liberté réelle du choix.</td></tr>
+</table>
+
+<h2>Pour aller plus loin</h2>
+<p>La fin de vie n'est qu'un des sujets de société qui divisent les candidats à la présidentielle 2027. Sur le Quizz du Berger :</p>
+<ul>
+<li><a href="/question-politique/euthanasie-loi-france">Fin de vie et euthanasie</a> — la question complète et les réponses détaillées des ${candidatesCount} candidats.</li>
+<li><a href="/theme/societe">Société</a> — laïcité, GPA/PMA, cannabis et autres questions de société.</li>
+<li><a href="/theme/sante">Santé</a> — soins palliatifs, déserts médicaux, budget hospitalier.</li>
+</ul>
+
+<p><a href="/themes">→ Faire le quiz</a></p>
+`,
+    schema: {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: `Loi sur l'aide à mourir : tout comprendre et les positions des ${candidatesCount} candidats à la présidentielle 2027`,
+      description:
+        "Contenu de la loi sur l'aide à mourir adoptée le 15 juillet 2026, chronologie de la navette parlementaire, saisine du Conseil constitutionnel et positions détaillées des candidats à la présidentielle 2027.",
+      author: { '@type': 'Person', name: 'Arnaud Ambroselli' },
+      datePublished: '2026-07-18',
+      about: [
+        { '@type': 'Thing', name: 'Aide à mourir' },
+        { '@type': 'Thing', name: 'Fin de vie en France' },
+        { '@type': 'Thing', name: 'Euthanasie en France' },
+        { '@type': 'Thing', name: 'Élection présidentielle française de 2027' },
+      ],
+    },
+  },
 ];

--- a/app-tanstack/src/utils/seo.ts
+++ b/app-tanstack/src/utils/seo.ts
@@ -151,10 +151,10 @@ const hotTopicSlugs: Record<string, { slug: string; seoTitle: string; seoDescrip
     seoTitle: 'RIC (Référendum d\'Initiative Citoyenne) : les candidats 2027',
     seoDescription: 'RIC : les candidats à la présidentielle 2027 sont-ils pour ou contre le référendum d\'initiative citoyenne ?',
   },
-  'question-2027-sante-03': {
+  'question-2027-soc-07': {
     slug: 'euthanasie-loi-france',
-    seoTitle: 'Euthanasie : les positions des candidats à la présidentielle 2027',
-    seoDescription: 'Fin de vie, euthanasie, suicide assisté : que proposent les candidats à la présidentielle 2027 ?',
+    seoTitle: 'Aide à mourir : les positions des candidats à la présidentielle 2027',
+    seoDescription: 'Fin de vie, euthanasie, suicide assisté : que proposent les candidats à la présidentielle 2027 sur la loi sur l\'aide à mourir ?',
   },
   'question-2027-sante-05': {
     slug: 'deserts-medicaux-france',


### PR DESCRIPTION
## Why this topic

The Assemblée nationale **definitively adopted the "aide à mourir" (assisted-dying) law on 15 July 2026** (291 for / 241 against / 29 abstentions), after 3 rejections by the Senate, a failed joint committee, and a final "dernier mot" vote at the Assemblée. It's now being reviewed by the Conseil constitutionnel (referred by PM Lecornu on 14 July and Senate president Larcher on 16 July). This is:
- **Genuinely hot**: covered this week by franceinfo, Public Sénat, ICI, RTS, Aleteia, etc.
- **Not already covered**: no existing article touches fin de vie/euthanasie.
- **Substantive**: a real, cross-party dividing line (party groups split roughly along a "cadre actuel suffisant" vs "légalisation encadrée" vs "aller plus loin" axis, not a clean left/right split — e.g. LFI and Renaissance both voted mostly *for*, most of LR and RN voted *against*).

It **maps directly onto an existing quiz question** (`question-2027-soc-07`, "Que pensez-vous de la fin de vie et de l'euthanasie ?", theme Société), which already has an answer on file for all 26 candidates — so **no new question was needed**.

### Rejected alternatives
- **Marine Le Pen's ineligibility ruling (7 July) / presidential candidacy announcement** — hot, but it's a legal/horse-race story more than a policy dividing line; also touches candidate-status questions I didn't want to speculate on in an article.
- **Villepin's press conference / Cazeneuve's 86-page platform / PS primary (Ségolène Royal)** — all "will they run" stories, not a substantive policy question.
- These are noted here for the record but no PR content was built around them.

### Small fix bundled in
While wiring the internal link to the question's SEO page, I found `hotTopicSlugs['question-2027-sante-03']` in `seo.ts` no longer matches any real question `_id` (the euthanasia question is actually `question-2027-soc-07` after some past renumbering) — so its nice slug/SEO title were silently dead, falling back to an auto-slugified URL. I repointed the key to the correct id so `/question-politique/euthanasie-loi-france` resolves properly. I did **not** audit the other `hotTopicSlugs` entries (several looked similarly stale) — out of scope for this PR, flagging for a separate cleanup pass.

## Sources consulted
- [Adoption en lecture définitive — Assemblée nationale](``https://www.assemblee-nationale.fr/dyn/actualites-accueil-hub/adoption-en-lecture-definitive-de-la-proposition-de-loi-relative-au-droit-a-l-aide-a-mourir``)
- [Fin de vie : la loi définitivement adoptée — ICI](``https://www.ici.fr/infos/societe/fin-de-vie-la-loi-sur-le-droit-a-l-aide-a-mourir-definitivement-adoptee-par-le-parlement-3468982``)
- [La France adopte définitivement la loi — RTS](https://www.rts.ch/info/monde/2026/article/la-france-adopte-definitivement-la-loi-sur-l-aide-a-mourir-29304398.html)
- [Ce que contient le texte — Public Sénat](``https://www.publicsenat.fr/actualites/parlementaire/aide-a-mourir-ce-que-contient-le-texte-des-deputes-sur-le-point-detre-definitivement-adopte``)
- [Sénat — dossier législatif](https://www.senat.fr/travaux-parlementaires/textes-legislatifs/la-loi-en-clair/proposition-de-loi-relative-au-droit-a-laide-a-mourir.html)
- [Qui a voté quoi — LCP](https://lcp.fr/actualites/aide-a-mourir-qui-a-vote-quoi-a-l-assemblee-nationale-431842) / [franceinfo (recherche par député)](``https://www.franceinfo.fr/societe/euthanasie/decouvrez-si-votre-depute-a-vote-pour-ou-contre-la-loi-sur-l-aide-a-mourir_8108873.html``)
- [Analyse du scrutin n°8280 — Assemblée nationale](https://www.assemblee-nationale.fr/dyn/17/scrutins/8280)
- [Saisine du Conseil constitutionnel — Alliance Vita](https://www.alliancevita.org/2026/07/conseil-constitutionnel-va-etre-saisi/), [Larcher saisit le CC — presseagence.fr](https://presseagence.fr/paris-fin-de-vie-gerard-larcher-saisit-le-conseil-constitutionnel/)
- [Loi n° 2026-404 du 26 mai 2026 (soins palliatifs) — Légifrance](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054131776)
- Presidential-race context: [LCP — liste des candidats](``https://lcp.fr/actualites/presidentielle-2027-la-liste-des-candidats-deja-en-lice-et-des-pretendants-436373``) (used only to rule out the alternative topics, not cited in the article)

## Per-candidate position table

No new quiz question was added — every position below is the candidate's **existing quiz answer** on `question-2027-soc-07`, cross-checked where possible against how their parliamentary group voted on 15 July 2026. Please veto/adjust any row where the group-vote context doesn't actually reflect that specific candidate.

| Candidate | Quiz answer (existing) | Backing |
|---|---|---|
| Marine Le Pen | Cadre actuel suffisant | Quiz data; RN group voted ~unanimously against |
| Éric Zemmour | Cadre actuel suffisant | Quiz data only (not a sitting deputy) |
| Laurent Wauquiez | Cadre actuel suffisant | Quiz data; LR group (Droite Républicaine) voted 41 against / 5 for |
| Bruno Retailleau | Cadre actuel suffisant | Quiz data only (Senator, not in this Assemblée vote) |
| Xavier Bertrand | Cadre actuel suffisant | Quiz data only |
| Nicolas Dupont-Aignan | Cadre actuel suffisant | Quiz data; DLF deputy, no confirmed individual vote found |
| David Lisnard | Cadre actuel suffisant | Quiz data only |
| François Bayrou | Cadre actuel suffisant | Quiz data; MoDem group split 20 for / 16 against — **flagging as estimate-adjacent**, his own vote wasn't confirmed |
| Gérald Darmanin | Cadre actuel suffisant | Quiz data only (Minister, doesn't vote as deputy) |
| Gabriel Attal | Légalisation encadrée | Quiz data; Ensemble pour la République group voted 64 for / 18 against |
| Édouard Philippe | Légalisation encadrée | Quiz data; Horizons group split 16 for / 18 against — **flagging as estimate-adjacent** |
| Raphaël Glucksmann | Légalisation encadrée | Quiz data only (MEP, no Assemblée vote) |
| Jérôme Guedj | Légalisation encadrée | Quiz data; PS group voted 60 for / 4 against |
| François Hollande | Légalisation encadrée | Quiz data only |
| Bernard Cazeneuve | Légalisation encadrée | Quiz data only |
| Marine Tondelier | Légalisation encadrée | Quiz data; Écologiste et Social group voted 35 for / 1 against |
| François Ruffin | Légalisation encadrée | Quiz data only (not confirmed if he still sits with a group that voted this way) |
| Fabien Roussel | Légalisation encadrée | Quiz data; GDR group voted 11 for / 2 against |
| Dominique de Villepin | Légalisation encadrée | Quiz data only |
| François Asselineau | Légalisation encadrée | Quiz data only |
| Patrick Sébastien | Légalisation encadrée | Quiz data only |
| Jean-Luc Mélenchon | Va plus loin (droit fondamental) | Quiz data; LFI group voted mostly for, but his own quiz answer is more expansive than the adopted text |
| Clémentine Autain | Va plus loin | Quiz data only |
| Nathalie Arthaud | Va plus loin | Quiz data only |
| Delphine Batho | Va plus loin | Quiz data only |
| Juan Branco | Va plus loin | Quiz data only |

**Please double check** the rows marked "estimate-adjacent" (Bayrou, Philippe) and any others where I cited a group-level vote as supporting context for an individual candidate's position — the group split, so the read might not match. No candidate was left without a position; all 26 already had one on file.

## Validation
- `cd app-tanstack && npm install && npm run typecheck` — no new errors (the 4 `@prisma/client`/`express` module-not-found errors are pre-existing, reproduced identically on `main` before this change, caused by `api-express` deps not being installed in this environment).
- No quiz question was added, so no `quizz-2027.json`/`candidates-answers.json` sync was needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_012DgSNN39gjBC3MZ3uwoZzA)_