### PR TITLE
blog: Sécheresse historique et loi d'urgence agricole : les positions des candidats 2027 sur l'eau

### DIFF
--- a/app-tanstack/src/content/articles.ts
+++ b/app-tanstack/src/content/articles.ts
@@ -1056,4 +1056,128 @@ export const articles: Article[] = [
       ],
     },
   },
+  {
+    slug: 'crise-eau-secheresse-france-candidats-2027',
+    title: `Sécheresse historique et loi d'urgence agricole : les positions des ${candidatesCount} candidats à la présidentielle 2027 sur l'eau`,
+    excerpt:
+      "99 départements sous restrictions d'eau, une sécheresse plus sévère qu'en 2022, et un vote solennel à l'Assemblée nationale ce 20 juillet sur la loi d'urgence agricole : la crise de l'eau s'invite dans la présidentielle 2027. Bassines, sobriété ou statu quo : où se situent les candidats ?",
+    date: '2026-07-20',
+    tag: 'Analyse',
+    content: `
+<p>Le printemps le plus chaud jamais mesuré, le mois de juin le plus chaud jamais enregistré, et désormais <strong>99 départements</strong> sous arrêté de restriction d'eau : la France traverse en 2026 une sécheresse plus sévère que celle de 2022, jusqu'ici année de référence. Ce <strong>20 juillet</strong>, l'Assemblée nationale vote solennellement la loi d'urgence agricole, qui prévoit de doubler d'ici 2035 les capacités de stockage d'eau pour l'agriculture — autrement dit, de faciliter la construction de bassines. Voici ce qu'il faut savoir, et les positions des ${candidatesCount} candidats à la présidentielle 2027.</p>
+
+<h2>Une sécheresse hors norme</h2>
+<p>Chronologie d'une crise qui s'aggrave de mois en mois :</p>
+<ul>
+<li><strong>Printemps 2026</strong> : le printemps le plus chaud jamais mesuré en France (+1,7 °C au-dessus des normales), avec un déficit de précipitations d'environ 30 %.</li>
+<li><strong>Fin mai 2026</strong> : un épisode de chaleur précoce et inhabituel touche le pays.</li>
+<li><strong>Juin 2026</strong> : le mois de juin le plus chaud jamais observé en France, avec une température moyenne de 22,75 °C (+3,8 °C par rapport aux normales), devançant le record de juin 2003.</li>
+<li><strong>1er juillet 2026</strong> : face à la canicule, la ministre de l'Agriculture Annie Genevard annonce un plan de mesures d'urgence (accélération des indemnisations d'assurance récolte, aides à l'équipement des élevages en brumisation et ventilation, soutien au transport de fourrage, fonds hydraulique agricole pour financer des retenues d'eau).</li>
+<li><strong>9 juillet 2026</strong> : 95 des 96 départements métropolitains sont concernés par au moins une mesure de restriction d'eau — seule la Haute-Corse est épargnée.</li>
+<li><strong>16 juillet 2026</strong> : députés et sénateurs réunis en commission mixte paritaire (CMP) trouvent un compromis sur la loi d'urgence agricole, adopté par 8 voix (élus centristes, de droite et d'extrême droite) contre 4 (élus de gauche), avec 2 abstentions (macronistes).</li>
+<li><strong>17 juillet 2026</strong> : 99 départements sont désormais concernés par une restriction, dont <strong>48 en situation de crise</strong> (le niveau le plus grave) et 23 en alerte renforcée. 206 arrêtés préfectoraux sur l'eau sont en vigueur, un niveau inédit depuis au moins 2013. 93 % des points de suivi des nappes phréatiques affichent un niveau en baisse, 54 % sont sous les normales mensuelles.</li>
+<li><strong>20 juillet 2026</strong> : vote solennel du texte à l'Assemblée nationale.</li>
+<li><strong>21 juillet 2026</strong> : vote solennel prévu au Sénat, pour une adoption définitive.</li>
+</ul>
+<p>Ne pas respecter un arrêté de restriction constitue une contravention de 5ᵉ classe, punie d'une amende pouvant aller jusqu'à 1 500 euros, portée à 3 000 euros en cas de récidive.</p>
+
+<h2>Que contient la loi d'urgence agricole ?</h2>
+<p>Le texte issu du compromis du 16 juillet prévoit notamment :</p>
+<ul>
+<li>Le <strong>doublement d'ici 2035</strong> des capacités de stockage d'eau agricole, avec une simplification des procédures de consultation publique pour la construction de retenues d'eau (bassines).</li>
+<li>Une <strong>dérogation ministérielle de trois ans maximum</strong>, sur avis de l'Anses, permettant l'usage de deux insecticides néonicotinoïdes interdits en France (flupyradifurone, acétamipride) sur les cultures de betterave, pomme, cerise et noisette — un point hérité du débat sur la <a href="https://fr.wikipedia.org/wiki/Loi_Duplomb">loi Duplomb</a>, promulguée le 12 août 2025 après une censure partielle du Conseil constitutionnel.</li>
+<li>Le retrait, par rapport à la version votée au Sénat, d'un principe de « non-régression agricole » qui aurait limité toute nouvelle contrainte sur les prélèvements d'eau agricoles — un recul salué par la FNSEA, dénoncé par les parlementaires de gauche.</li>
+</ul>
+
+<h2>Pourquoi ce dossier divise</h2>
+
+<h3>1. Bassines et « guerre de l'eau »</h3>
+<p>Depuis les affrontements de <strong>Sainte-Soline</strong> en 2023, les bassines (ou retenues de substitution) cristallisent l'opposition entre agriculteurs irrigants et défenseurs de l'environnement. Le 28 mars 2026, la Coordination Rurale a manifesté devant la mégabassine de Sainte-Soline, tandis qu'un collectif « Bassines non merci » s'est constitué en Touraine contre un projet de retenue relancé en Indre-et-Loire. Plusieurs élus locaux, dont le représentant de France Urbaine Ludovic Brossard, ont mis en garde contre le risque d'une véritable « guerre de l'eau » entre usages agricoles, industriels et domestiques.</p>
+
+<h3>2. S'adapter à la chaleur : climatiser ou sobriété ?</h3>
+<p>Le 19 juin 2026, en pleine canicule, un échange vif a opposé Marine Le Pen et Jean-Luc Mélenchon sur franceinfo. Marine Le Pen a annoncé vouloir mettre en place, si elle est élue, un « plan de climatisation massif », en priorité pour « les hôpitaux, les maisons de retraite, les écoles ». Jean-Luc Mélenchon a rétorqué : « Climatiser partout, ça veut dire augmenter les dégâts », en défendant plutôt son projet d'« écorégions » organisées autour des bassins versants pour « faire entrer l'eau dans le débat ».</p>
+
+<h3>3. Changer de modèle agricole ou le protéger ?</h3>
+<p>Pour une partie des candidats, la sécheresse impose de repenser en profondeur les cultures irriguées (maïs, notamment) et l'élevage intensif. Pour d'autres, la priorité est de sécuriser l'approvisionnement en eau des exploitations existantes, quitte à accélérer la construction d'infrastructures de stockage.</p>
+
+<h2>Les positions des ${candidatesCount} candidats à la présidentielle 2027</h2>
+<p>Sur la question <a href="/question-politique/crise-eau-secheresse-france">« Comment la France devrait-elle gérer la crise de l'eau et les sécheresses ? »</a> du Quizz du Berger, les ${candidatesCount} candidats se répartissent en trois familles nettes. Fait notable : <strong>aucun</strong> ne choisit l'option la plus légère du quiz (« on fait beaucoup de bruit pour pas grand-chose, la France ne manque pas d'eau »).</p>
+
+<h3>Famille 1 — Changer radicalement le modèle agricole, priorité absolue</h3>
+<p>Ces candidats jugent que la crise de l'eau impose une transformation en profondeur du modèle agricole français, plutôt que des solutions techniques comme les bassines.</p>
+<ul>
+<li><a href="/candidat/jean-luc-melenchon">Jean-Luc Mélenchon</a> (LFI) — Défend le projet d'« écorégions » organisées autour des bassins versants ; opposé à la climatisation généralisée comme réponse à la chaleur.</li>
+<li><a href="/candidat/clementine-autain">Clémentine Autain</a> — Alignée sur la ligne LFI : la crise de l'eau appelle une rupture avec le modèle agro-industriel.</li>
+<li><a href="/candidat/marine-tondelier">Marine Tondelier</a> (Les Écologistes) — Priorité à la sobriété et à la transformation des pratiques agricoles plutôt qu'à l'infrastructure de stockage.</li>
+<li><a href="/candidat/delphine-batho">Delphine Batho</a> (Génération Écologie) — Ligne écologiste constante : la sécheresse est une conséquence directe d'un modèle à bout de souffle.</li>
+<li><a href="/candidat/nathalie-arthaud">Nathalie Arthaud</a> (LO) — Dénonce un système agro-industriel organisé pour le profit plutôt que pour l'intérêt collectif.</li>
+<li><a href="/candidat/juan-branco">Juan Branco</a> — Opposition au modèle agro-industriel actuel, jugé incompatible avec les limites écologiques.</li>
+</ul>
+
+<h3>Famille 2 — Mieux partager l'eau, avec des restrictions encadrées</h3>
+<p>Ces candidats défendent un partage plus équilibré de la ressource entre agriculture, industrie et particuliers, avec des restrictions en période de sécheresse plutôt qu'un choix radical dans un sens ou dans l'autre. Cette famille traverse tout l'échiquier politique.</p>
+<ul>
+<li><a href="/candidat/gabriel-attal">Gabriel Attal</a> (Renaissance) — Ligne gouvernementale : gestion équilibrée de la ressource, articulée au plan Genevard du 1er juillet.</li>
+<li><a href="/candidat/edouard-philippe">Édouard Philippe</a> (Horizons) — Position pragmatique : partage de l'eau entre usages, sans rejeter ni les restrictions ni le stockage ciblé.</li>
+<li><a href="/candidat/francois-bayrou">François Bayrou</a> (MoDem) — Ligne centriste classique : arbitrage entre les usages plutôt que solution unique.</li>
+<li><a href="/candidat/raphael-glucksmann">Raphaël Glucksmann</a> (Place Publique) — Défend une gestion de l'eau qui protège à la fois l'agriculture et les écosystèmes.</li>
+<li><a href="/candidat/jerome-guedj">Jérôme Guedj</a> (PS) — Ligne social-démocrate : régulation des usages de l'eau plutôt que logique d'affrontement.</li>
+<li><a href="/candidat/francois-hollande">François Hollande</a> — Plaide pour un partage négocié de la ressource entre les différents usagers.</li>
+<li><a href="/candidat/bernard-cazeneuve">Bernard Cazeneuve</a> — Position d'équilibre entre soutien aux agriculteurs et préservation de la ressource.</li>
+<li><a href="/candidat/fabien-roussel">Fabien Roussel</a> (PCF) — Défend les agriculteurs tout en soutenant une répartition organisée de l'eau entre usages.</li>
+<li><a href="/candidat/francois-ruffin">François Ruffin</a> — Sensible à la situation des agriculteurs, privilégie un partage encadré plutôt que la seule fuite en avant vers les bassines.</li>
+<li><a href="/candidat/dominique-de-villepin">Dominique de Villepin</a> — Ligne institutionnelle : gestion raisonnée et négociée de la ressource en eau.</li>
+</ul>
+
+<h3>Famille 3 — Construire des retenues d'eau et des bassines</h3>
+<p>Ces candidats jugent prioritaire de sécuriser l'accès à l'eau des exploitations agricoles par des infrastructures de stockage, dans la ligne de la loi d'urgence agricole votée ce 20 juillet.</p>
+<ul>
+<li><a href="/candidat/marine-le-pen">Marine Le Pen</a> (RN) — A annoncé un « plan de climatisation massif » pour les bâtiments sensibles ; défend aussi les retenues d'eau pour l'agriculture. Le RN a voté le compromis de la CMP du 16 juillet.</li>
+<li><a href="/candidat/laurent-wauquiez">Laurent Wauquiez</a> (LR) — Soutient le doublement des capacités de stockage d'eau porté par la loi d'urgence agricole, dans la continuité de la loi Duplomb.</li>
+<li><a href="/candidat/bruno-retailleau">Bruno Retailleau</a> (LR) — Défend la sécurisation de l'irrigation par les bassines comme réponse structurelle à la sécheresse.</li>
+<li><a href="/candidat/xavier-bertrand">Xavier Bertrand</a> — Ligne similaire : priorité aux infrastructures pour que les agriculteurs puissent continuer à produire.</li>
+<li><a href="/candidat/gerald-darmanin">Gérald Darmanin</a> — Soutient le compromis de la CMP sur le stockage de l'eau agricole.</li>
+<li><a href="/candidat/david-lisnard">David Lisnard</a> — Libéral assumé, favorable aux solutions d'infrastructure plutôt qu'aux restrictions généralisées.</li>
+<li><a href="/candidat/eric-zemmour">Éric Zemmour</a> (Reconquête) — Défend la souveraineté alimentaire par la sécurisation de l'irrigation, opposé aux contraintes écologistes jugées punitives.</li>
+<li><a href="/candidat/nicolas-dupont-aignan">Nicolas Dupont-Aignan</a> (DLF) — Priorité à l'outil agricole français, favorable aux retenues d'eau.</li>
+<li><a href="/candidat/francois-asselineau">François Asselineau</a> (UPR) — Défend la souveraineté alimentaire, ce qui passe selon lui par la sécurisation de l'irrigation.</li>
+<li><a href="/candidat/patrick-sebastien">Patrick Sébastien</a> — Prend la défense du monde agricole et de ses besoins en eau pour continuer à produire.</li>
+</ul>
+
+<h2>Bassines : arguments pour et arguments contre</h2>
+<table>
+<tr><th>Arguments en faveur des retenues d'eau</th><th>Arguments contre, ou pour la sobriété</th></tr>
+<tr><td>Sécurise l'irrigation des exploitations face à des sécheresses de plus en plus fréquentes.</td><td>Prélève l'eau en hiver au détriment de la recharge naturelle des nappes et des cours d'eau.</td></tr>
+<tr><td>Le doublement du stockage d'ici 2035 est présenté comme une réponse structurelle, pas seulement d'urgence.</td><td>Favorise le maintien de cultures gourmandes en eau plutôt qu'une évolution des pratiques agricoles.</td></tr>
+<tr><td>La loi Duplomb encadre les nouvelles retenues : pas de prélèvement dans les nappes profondes, protection des espèces.</td><td>Le compromis du 16 juillet a supprimé le principe de « non-régression agricole » porté par le Sénat.</td></tr>
+<tr><td>Soutenue par la FNSEA et une large partie du monde agricole.</td><td>Contestée par les collectifs écologistes, qui redoutent une « guerre de l'eau » entre usages.</td></tr>
+<tr><td>S'accompagne de mesures d'urgence (assurance récolte, aides à l'équipement) pour amortir la crise actuelle.</td><td>Ne répond pas, selon les opposants, à la cause de fond : le dérèglement climatique et l'intensité des cultures irriguées.</td></tr>
+</table>
+
+<h2>Pour aller plus loin</h2>
+<p>La crise de l'eau recoupe plusieurs thèmes du Quizz du Berger :</p>
+<ul>
+<li><a href="/question-politique/crise-eau-secheresse-france">Crise de l'eau et sécheresse</a> — la question complète et les réponses détaillées des ${candidatesCount} candidats.</li>
+<li><a href="/theme/agriculture-et-alimentation">Agriculture et alimentation</a> — pesticides, bio, indépendance alimentaire, élevage.</li>
+<li><a href="/theme/climat-energie-et-ecologie">Climat, énergie et écologie</a> — sobriété énergétique, adaptation au changement climatique.</li>
+</ul>
+
+<p><a href="/themes">→ Faire le quiz</a></p>
+`,
+    schema: {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: `Sécheresse historique et loi d'urgence agricole : les positions des ${candidatesCount} candidats à la présidentielle 2027 sur l'eau`,
+      description:
+        "Sécheresse 2026, 99 départements sous restrictions d'eau, loi d'urgence agricole votée le 20 juillet : ce qu'il faut savoir et les positions détaillées des candidats à la présidentielle 2027 sur la crise de l'eau.",
+      author: { '@type': 'Person', name: 'Arnaud Ambroselli' },
+      datePublished: '2026-07-20',
+      about: [
+        { '@type': 'Thing', name: 'Sécheresse en France' },
+        { '@type': 'Thing', name: 'Loi d\'urgence agricole' },
+        { '@type': 'Thing', name: 'Bassines' },
+        { '@type': 'Thing', name: 'Élection présidentielle française de 2027' },
+      ],
+    },
+  },
 ];

--- a/app-tanstack/src/utils/seo.ts
+++ b/app-tanstack/src/utils/seo.ts
@@ -111,6 +111,11 @@ const hotTopicSlugs: Record<string, { slug: string; seoTitle: string; seoDescrip
     seoTitle: 'Agriculture biologique : les positions des candidats 2027',
     seoDescription: `Quelle place pour le bio en France ? Découvrez les positions des ${candidatesCount} candidats à la présidentielle 2027.`,
   },
+  'question-2027-agri-02': {
+    slug: 'crise-eau-secheresse-france',
+    seoTitle: 'Crise de l\'eau et sécheresse : les positions des candidats à la présidentielle 2027',
+    seoDescription: `Bassines, restrictions, sobriété : comment gérer la sécheresse ? Comparez les positions des ${candidatesCount} candidats à la présidentielle 2027.`,
+  },
   'question-2027-climat-02': {
     slug: 'nucleaire-france-avenir',
     seoTitle: 'Nucléaire en France : que proposent les candidats à la présidentielle 2027 ?',


### PR DESCRIPTION
## Pourquoi ce sujet

La France traverse en juillet 2026 une sécheresse plus sévère que celle de 2022 (99/100 départements sous restriction d'eau, 48 en crise), et l'Assemblée nationale vote **ce 20 juillet** (jour de rédaction) la loi d'urgence agricole, qui double d'ici 2035 les capacités de stockage d'eau agricole (bassines). C'est hot (plusieurs dizaines d'articles cette semaine dans la presse spécialisée et généraliste), pas encore couvert par le blog, et substantiel : le vote en commission mixte paritaire du 16 juillet s'est joué à 8 voix (centre/droite/RN) contre 4 (gauche), 2 abstentions (macronistes) — une vraie ligne de fracture.

Le sujet **mappe directement** sur une question déjà existante du quiz (`question-2027-agri-02`, thème Agriculture), pour laquelle **tous les 26 candidats ont déjà une réponse enregistrée** — donc peu d'estimation nécessaire. Cette question n'avait pas encore de page SEO dédiée (`hotTopicSlugs`), je l'ai ajoutée (`crise-eau-secheresse-france`).

**Aucune nouvelle question créée** — pas de risque sur les 3 copies de `quizz-2027.json`/`candidates-answers.json`.

### Sujets écartés
- **Elon Musk / soutien à Marine Le Pen ("dernier espoir de la France")** : hot (15-16 juillet), mais l'angle "ingérence étrangère" ne mappe sur aucune question existante et m'a semblé plus proche du fait divers/polémique média que d'une ligne de clivage programmatique claire entre les 26 candidats — j'ai préféré ne pas forcer une nouvelle question dessus sans validation éditoriale.
- **Budget 2027 ("budget de sauvegarde républicaine", 30-50 Md€ d'économies)** : hot mais encore trop en amont (texte déposé le 30 septembre seulement) pour un article factuel daté.
- **Loi "réponses immédiates aux phénomènes troublant l'ordre public" (adoptée le 15/07)** et **projet de loi protection de l'enfant** (vote le 21/07) : moins de clivage net entre candidats identifiable rapidement, gardés en réserve pour un prochain article.

## Sources consultées

- [franceinfo — actualité politique de la semaine](https://www.franceinfo.fr/politique/)
- [Portail Réussir — Sécheresse 2026 : 48 départements en crise](``https://www.reussir.fr/secheresse-2026-quels-departements-affichent-deja-des-restrictions-deau-pour-les-activites``)
- [Selectra — 95 départements sous restriction (9 juillet 2026)](https://selectra.info/energie/actualites/marche/secheresse-restrictions-eau-durcies-week-end-juillet-2026)
- [agriculture.gouv.fr — plan Genevard du 1er juillet 2026](``https://agriculture.gouv.fr/face-a-la-crise-caniculaire-annie-genevard-annonce-un-ensemble-de-mesures-durgence-et-danticipation``)
- [Public Sénat — compromis en CMP sur la loi d'urgence agricole (16 juillet 2026)](``https://www.publicsenat.fr/actualites/parlementaire/projet-de-loi-durgence-agricole-deputes-et-senateurs-parviennent-a-un-accord-en-commission-mixte-paritaire)``
- [JA Mag — accord parlementaire avant le vote final (votes solennels 20 et 21 juillet)](https://www.jamag.fr/actualites/loi-durgence-agricole-accord-parlementaire-trouve-avant-le-vote-final)
- ``[franceinfo — le Sénat assouplit la gestion de l'eau, le gouvernement irrité](https://www.franceinfo.fr/economie/emploi/metiers/agriculture/loi-d-urgence-agricole-le-senat-vote-des-assouplissements-supplementaires-dans-la-gestion-de-l-eau-pour-l-agriculture-irritant-le-gouvernement_8087777.html)``
- [franceinfo — clash Mélenchon/Le Pen sur la climatisation (19 juin 2026)](``https://www.franceinfo.fr/politique/marine-le-pen/climatiser-partout-ca-veut-dire-augmenter-les-degats-passe-d-armes-entre-jean-luc-melenchon-et-marine-le-pen-en-pleine-vague-de-chaleur_8069294.html)``
- [Public Sénat — loi Duplomb, censure et réserves du Conseil constitutionnel](https://www.publicsenat.fr/actualites/politique/loi-duplomb-apres-la-censure-que-contient-le-texte)
- [Usine Nouvelle — mégabassines, tensions Deux-Sèvres](``https://www.usinenouvelle.com/article/que-sont-ces-bassines-sources-de-tensions-entre-agriculteurs-et-ecologistes-dans-les-deux-sevres.N2061687``)

## Aucune nouvelle question — juste une nouvelle page SEO

Ajout dans `hotTopicSlugs` (`app-tanstack/src/utils/seo.ts`) pour la question existante `question-2027-agri-02` :
```
slug: 'crise-eau-secheresse-france'
seoTitle: "Crise de l'eau et sécheresse : les positions des candidats à la présidentielle 2027"
```
Aucune modification des 3 `quizz-2027.json` ni des 3 `candidates-answers.json`.

## Positions par candidat (toutes issues des données du quiz existantes)

Réparties d'après `answerIndex` déjà enregistré pour `question-2027-agri-02` — **aucune estimation**, seulement de la mise en contexte factuelle (votes CMP, déclarations publiques) autour d'un choix déjà arbitré par Arnaud.

| Candidat | Position (quiz) | Statut |
|---|---|---|
| Jean-Luc Mélenchon, Clémentine Autain, Marine Tondelier, Delphine Batho, Nathalie Arthaud, Juan Branco | Changer radicalement le modèle agricole | **Donnée du quiz** |
| Gabriel Attal, Édouard Philippe, François Bayrou, Raphaël Glucksmann, Jérôme Guedj, François Hollande, Bernard Cazeneuve, Fabien Roussel, François Ruffin, Dominique de Villepin | Mieux partager l'eau, avec restrictions | **Donnée du quiz** |
| Marine Le Pen, Laurent Wauquiez, Bruno Retailleau, Xavier Bertrand, Gérald Darmanin, David Lisnard, Éric Zemmour, Nicolas Dupont-Aignan, François Asselineau, Patrick Sébastien | Construire des retenues d'eau / bassines | **Donnée du quiz** |

Deux ajouts contextuels sourcés au-delà de la donnée du quiz, à vérifier :
- **Marine Le Pen** : mention de son « plan de climatisation massif » annoncé le 19/06/2026 (sourcé, cf. lien franceinfo ci-dessus) — vient en complément de sa position quiz sur les bassines, ne la remplace pas.
- **RN a voté le compromis CMP du 16/07** : fait rapporté par Public Sénat sur le vote des groupes parlementaires (élus RN dans le bloc des 8 voix « centre/droite/extrême droite ») — à vérifier si l'attribution à Marine Le Pen spécifiquement doit être nuancée avant publication.

Merci de vérifier notamment le classement de François Ruffin et Fabien Roussel (famille 2, partage/restrictions) et de Nicolas Dupont-Aignan/François Asselineau (famille 3, bassines) qui reposent sur la donnée quiz mais dont je n'ai pas trouvé de déclaration publique récente et spécifique sur la sécheresse 2026 pour confirmer.

## Validation

- `cd app-tanstack && npm install && npm run typecheck` → ✅ passe sans erreur
- Aucune modification des fichiers `quizz-2027.json` / `candidates-answers.json` (les 3 copies restent identiques, vérifié par diff)
- Pas de régénération du sitemap, pas touché à la DB

---

🤖 Généré par Claude Code (routine automatisée de blog). PR en brouillon pour relecture avant merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1LYH2x1pfQsGjp4QVvpaw)_