### PR TITLE
blog: Réseaux sociaux interdits aux moins de 15 ans : tout comprendre et les positions des candidats à la présidentielle 2027

### DIFF
--- a/app-tanstack/src/content/articles.ts
+++ b/app-tanstack/src/content/articles.ts
@@ -1180,4 +1180,121 @@ export const articles: Article[] = [
       ],
     },
   },
+  {
+    slug: 'interdiction-reseaux-sociaux-mineurs-france-candidats-2027',
+    title: `Réseaux sociaux interdits aux moins de 15 ans : tout comprendre et les positions des ${candidatesCount} candidats à la présidentielle 2027`,
+    excerpt:
+      "Le 21 juillet 2026, la France est devenue le premier pays d'Europe à interdire les réseaux sociaux aux moins de 15 ans. Que contient la loi, pourquoi divise-t-elle, et où se situent les candidats à 2027 ?",
+    date: '2026-07-23',
+    tag: 'Analyse',
+    content: `
+<p>Après un an et demi de navette parlementaire, le Parlement français a définitivement adopté, le <strong>21 juillet 2026</strong>, une loi interdisant l'accès aux réseaux sociaux aux mineurs de moins de 15 ans. La France devient ainsi le premier pays de l'Union européenne à franchir ce cap. Le texte, porté depuis juin 2025 par Emmanuel Macron, a été voté à une large majorité (279 voix pour, 81 contre à l'Assemblée nationale), mais il continue de diviser sur son efficacité, sa constitutionnalité et son impact sur la vie privée. Voici ce qu'il faut savoir, et les positions des ${candidatesCount} candidats à la présidentielle 2027.</p>
+
+<h2>Que contient la loi sur les réseaux sociaux et les mineurs ?</h2>
+<p>Le texte instaure une <strong>interdiction générale d'accès aux réseaux sociaux</strong> (Instagram, TikTok, Facebook, Snapchat, etc.) pour les mineurs de moins de 15 ans. Des exceptions sont prévues pour les « encyclopédies en ligne » et les « projets numériques à vocation éducative ».</p>
+<p>La vérification repose sur un <strong>jeton d'âge anonymisé</strong> : chaque utilisateur, mineur ou majeur, devra prouver son âge auprès d'un tiers de confiance, public (France Identité) ou privé, sans que la plateforme n'ait accès à son identité complète. L'<strong>Arcom</strong> (Autorité de régulation de la communication audiovisuelle et numérique) est chargée de faire respecter l'interdiction.</p>
+
+<h2>Chronologie</h2>
+<ul>
+<li><strong>10 juin 2025</strong> : après le meurtre d'une surveillante par un élève de 14 ans à Nogent-sur-Seine, Emmanuel Macron relance l'idée d'une interdiction des réseaux sociaux avant 15 ans, en menaçant d'agir au niveau français si l'Union européenne ne bouge pas.</li>
+<li><strong>Premier semestre 2026</strong> : la proposition de loi fait la navette entre l'Assemblée nationale et le Sénat, qui la modifie notamment sur le mécanisme de vérification d'âge.</li>
+<li><strong>20 juillet 2026</strong> : députés et sénateurs s'accordent en commission mixte paritaire (CMP) sur une version commune du texte, avec un âge minimal fixé à 15 ans.</li>
+<li><strong>21 juillet 2026</strong> : adoption définitive par le Parlement. À l'Assemblée nationale, le vote rassemble la majorité présidentielle, la droite et le Rassemblement national (279 voix pour). Seul le groupe LFI vote contre ; les députés socialistes s'abstiennent tout en annonçant vouloir saisir le Conseil constitutionnel.</li>
+<li><strong>1er septembre 2026</strong> : entrée en vigueur pour les nouveaux comptes — plus aucune création de compte pour un mineur de moins de 15 ans.</li>
+<li><strong>1er janvier 2027</strong> : début de la vérification des comptes déjà existants.</li>
+</ul>
+
+<h2>Pourquoi cette loi divise</h2>
+
+<h3>1. Protection de l'enfance contre autonomie numérique</h3>
+<p>Pour ses soutiens, la loi répond à une urgence : addiction aux écrans, exposition précoce à des contenus violents ou pornographiques, harcèlement en ligne, mécanismes addictifs des plateformes conçus pour capter l'attention des plus jeunes. Pour ses opposants, une interdiction générale et absolue prive aussi les mineurs d'usages positifs (information, expression, lien social) et traite le symptôme plutôt que la cause.</p>
+
+<h3>2. Une loi difficile à appliquer ?</h3>
+<p>La faisabilité technique du dispositif est très discutée. Une étude de l'université de Melbourne publiée en juin 2026 montre qu'en Australie, qui a adopté une interdiction comparable pour les moins de 16 ans, moins de 20 % des mineurs concernés la respectent réellement : VPN, faux documents d'identité ou comptes empruntés aux parents permettent de contourner facilement le contrôle.</p>
+
+<h3>3. Vie privée et anonymat en ligne</h3>
+<p>Le mécanisme du jeton d'âge, bien que présenté comme anonymisé, inquiète une partie de la classe politique et des associations de défense des libertés numériques : il implique que <strong>tous les utilisateurs</strong>, pas seulement les mineurs, prouvent leur âge auprès d'un tiers de confiance pour continuer à utiliser les réseaux sociaux. C'est l'un des arguments mis en avant par les députés qui ont voté contre ou se sont abstenus.</p>
+
+<h3>4. Un risque constitutionnel et un bras de fer avec le droit européen</h3>
+<p>Les députés socialistes, qui se sont abstenus lors du vote final, ont annoncé vouloir saisir le Conseil constitutionnel : une interdiction générale et absolue pourrait être jugée disproportionnée par rapport à l'objectif de protection des mineurs, certains estimant que seules certaines fonctionnalités des plateformes (recommandation algorithmique, notifications, messagerie) posent réellement problème. Par ailleurs, la plupart des grandes plateformes sont enregistrées en Irlande et relèvent donc, pour une partie de leur régulation, du droit européen : l'application extraterritoriale de la loi française reste un point d'incertitude juridique.</p>
+
+<h2>Les positions des ${candidatesCount} candidats à la présidentielle 2027</h2>
+<p>Sur la question <a href="/question-politique/interdiction-reseaux-sociaux-mineurs-15-ans">« Les réseaux sociaux et les écrans chez les jeunes, ça vous inquiète ? »</a> du <a href="/theme/numerique-et-ia">Quizz du Berger</a>, les ${candidatesCount} candidats se répartissent en trois familles.</p>
+
+<h3>Famille 1 — Interdiction stricte, dans l'esprit de la loi (voire plus loin)</h3>
+<p>Ces candidats jugent les réseaux sociaux comme le problème numéro un de la jeunesse actuelle et défendent une interdiction pure et simple avant 16 ans, une position plus stricte encore que la loi votée le 21 juillet (15 ans). Sans surprise, la plupart de ces candidats ou de leurs partis ont voté en faveur du texte le 21 juillet.</p>
+<ul>
+<li><a href="/candidat/marine-le-pen">Marine Le Pen</a> (RN) — Le Rassemblement national a voté pour le texte à l'Assemblée nationale.</li>
+<li><a href="/candidat/gabriel-attal">Gabriel Attal</a> (Renaissance) — Le texte est porté par la majorité présidentielle dont il est issu ; son groupe a voté pour.</li>
+<li><a href="/candidat/gerald-darmanin">Gérald Darmanin</a> — Aligné sur la ligne gouvernementale, favorable à une interdiction ferme.</li>
+<li><a href="/candidat/bruno-retailleau">Bruno Retailleau</a> (LR) — Ligne sécuritaire et protectrice sur les questions liées à l'enfance, son groupe a voté pour le texte.</li>
+<li><a href="/candidat/eric-zemmour">Éric Zemmour</a> (Reconquête) — Défend une ligne ferme sur la protection de la jeunesse face aux plateformes numériques.</li>
+<li><a href="/candidat/nicolas-dupont-aignan">Nicolas Dupont-Aignan</a> (DLF) — Favorable à une interdiction stricte, dans la continuité de ses positions sur la souveraineté numérique.</li>
+<li><a href="/candidat/marine-tondelier">Marine Tondelier</a> (Les Écologistes) — Position la plus stricte du quiz, cohérente avec les mises en garde des Écologistes sur la santé mentale des jeunes et l'addiction aux écrans.</li>
+</ul>
+
+<h3>Famille 2 — Régulation forte des plateformes, sans interdiction générale</h3>
+<p>Majoritaires parmi les candidats, ils jugent le sujet préoccupant et veulent des règles fortes pour protéger les mineurs, sans nécessairement soutenir une interdiction générale et absolue comme celle votée le 21 juillet.</p>
+<ul>
+<li><a href="/candidat/jean-luc-melenchon">Jean-Luc Mélenchon</a> (LFI) — Sa réponse au quiz reflète une inquiétude réelle sur le sujet. Lors du vote du 21 juillet, le groupe LFI a toutefois voté contre ce texte précis, estimant qu'il ne s'attaque pas aux causes (modèles économiques des plateformes) et redoutant les risques du mécanisme de vérification d'âge pour l'anonymat en ligne.</li>
+<li><a href="/candidat/clementine-autain">Clémentine Autain</a> — Alignée sur la ligne LFI, y compris sur le vote contre le texte du 21 juillet.</li>
+<li><a href="/candidat/francois-ruffin">François Ruffin</a> — Sensible à la question de la jeunesse et de l'école, mais proche de la ligne LFI d'opposition à ce texte précis.</li>
+<li><a href="/candidat/fabien-roussel">Fabien Roussel</a> (PCF) — Favorable à une régulation forte des plateformes plutôt qu'à une interdiction générale.</li>
+<li><a href="/candidat/raphael-glucksmann">Raphaël Glucksmann</a> (Place Publique) — Ligne proche du PS : préoccupé par le sujet, mais son camp s'est abstenu lors du vote final et envisage une saisine du Conseil constitutionnel.</li>
+<li><a href="/candidat/jerome-guedj">Jérôme Guedj</a> (PS) — Le groupe socialiste s'est abstenu le 21 juillet, jugeant le texte potentiellement inconstitutionnel et inapplicable en l'état, tout en partageant l'objectif de mieux protéger les mineurs.</li>
+<li><a href="/candidat/francois-hollande">François Hollande</a> — Ligne proche du PS, favorable à une régulation forte plutôt qu'à une interdiction générale jugée fragile juridiquement.</li>
+<li><a href="/candidat/bernard-cazeneuve">Bernard Cazeneuve</a> — Préoccupé par le sujet, mais prudent sur une interdiction générale aux effets incertains.</li>
+<li><a href="/candidat/edouard-philippe">Édouard Philippe</a> (Horizons) — Favorable à une régulation forte des plateformes et à la protection des mineurs.</li>
+<li><a href="/candidat/laurent-wauquiez">Laurent Wauquiez</a> (LR) — Défend une régulation stricte des plateformes vis-à-vis des mineurs.</li>
+<li><a href="/candidat/xavier-bertrand">Xavier Bertrand</a> — Ligne proche de Wauquiez, favorable à une régulation forte.</li>
+<li><a href="/candidat/francois-bayrou">François Bayrou</a> (MoDem) — Position centriste : régulation forte des plateformes, protection des mineurs.</li>
+<li><a href="/candidat/dominique-de-villepin">Dominique de Villepin</a> — Préoccupé par l'emprise des plateformes sur la jeunesse, favorable à une régulation forte.</li>
+<li><a href="/candidat/nathalie-arthaud">Nathalie Arthaud</a> (LO) — Dénonce les logiques de profit des plateformes plutôt qu'une simple interdiction d'usage.</li>
+<li><a href="/candidat/francois-asselineau">François Asselineau</a> (UPR) — Favorable à une régulation forte, notamment au nom de la souveraineté numérique.</li>
+<li><a href="/candidat/delphine-batho">Delphine Batho</a> (Génération Écologie) — Ligne écologiste : préoccupée par l'impact des écrans sur la santé mentale des jeunes, favorable à une régulation forte.</li>
+<li><a href="/candidat/juan-branco">Juan Branco</a> — Critique des plateformes et de leurs logiques économiques, favorable à une régulation forte.</li>
+<li><a href="/candidat/patrick-sebastien">Patrick Sébastien</a> — Préoccupé par l'impact des écrans sur les jeunes générations, favorable à une régulation forte.</li>
+</ul>
+
+<h3>Famille 3 — Aux parents de gérer, pas à l'État</h3>
+<p>Une position minoritaire dans le quiz, qui renvoie la responsabilité à la sphère familiale plutôt qu'à la loi.</p>
+<ul>
+<li><a href="/candidat/david-lisnard">David Lisnard</a> — Ligne libérale assumée : l'encadrement du temps d'écran relève des parents, pas d'une interdiction décidée par l'État.</li>
+</ul>
+
+<h2>Ce que la loi interdit, et ce qu'elle ne change pas</h2>
+<table>
+<tr><th>Arguments en faveur de la loi</th><th>Arguments contre, ou réservés</th></tr>
+<tr><td>Répond à une urgence de santé publique : addiction aux écrans, exposition précoce à des contenus violents ou pornographiques.</td><td>Facilement contournable : en Australie, moins de 20 % des mineurs concernés respectent une interdiction comparable.</td></tr>
+<tr><td>Premier texte de ce type en Europe, qui peut accélérer une régulation au niveau de l'Union européenne.</td><td>Le mécanisme de vérification d'âge concerne en pratique tous les utilisateurs, pas seulement les mineurs, ce qui inquiète sur la vie privée et l'anonymat en ligne.</td></tr>
+<tr><td>Contrôle confié à l'Arcom, autorité indépendante déjà compétente sur le numérique.</td><td>Risque d'inconstitutionnalité : une interdiction générale et absolue pourrait être jugée disproportionnée.</td></tr>
+<tr><td>Large majorité parlementaire transpartisane (279 voix pour à l'Assemblée nationale).</td><td>Application juridiquement incertaine face au droit européen, la plupart des plateformes étant enregistrées en Irlande.</td></tr>
+</table>
+
+<h2>Pour aller plus loin</h2>
+<p>Cette loi s'inscrit dans un débat plus large sur le numérique, l'intelligence artificielle et la protection de la vie privée. Sur le Quizz du Berger, les thèmes et questions qui touchent à ces sujets :</p>
+<ul>
+<li><a href="/theme/numerique-et-ia">Numérique et IA</a> — IA, souveraineté numérique, surveillance, dématérialisation.</li>
+<li><a href="/question-politique/interdiction-reseaux-sociaux-mineurs-15-ans">Réseaux sociaux et écrans chez les jeunes</a> — la question complète et les réponses détaillées des ${candidatesCount} candidats.</li>
+<li><a href="/question-politique/intelligence-artificielle-regulation">Intelligence artificielle</a> — comment les candidats voient la régulation de l'IA.</li>
+</ul>
+
+<p><a href="/themes">→ Faire le quiz</a></p>
+`,
+    schema: {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: `Réseaux sociaux interdits aux moins de 15 ans : tout comprendre et les positions des ${candidatesCount} candidats à la présidentielle 2027`,
+      description:
+        "Loi interdisant les réseaux sociaux aux moins de 15 ans, adoptée le 21 juillet 2026 : contenu du texte, chronologie, débats et positions détaillées des candidats à la présidentielle 2027.",
+      author: { '@type': 'Person', name: 'Arnaud Ambroselli' },
+      datePublished: '2026-07-23',
+      about: [
+        { '@type': 'Thing', name: 'Réseaux sociaux' },
+        { '@type': 'Thing', name: 'Protection des mineurs' },
+        { '@type': 'Thing', name: 'Numérique' },
+        { '@type': 'Thing', name: 'Élection présidentielle française de 2027' },
+      ],
+    },
+  },
 ];

--- a/app-tanstack/src/utils/seo.ts
+++ b/app-tanstack/src/utils/seo.ts
@@ -211,6 +211,11 @@ const hotTopicSlugs: Record<string, { slug: string; seoTitle: string; seoDescrip
     seoTitle: 'Inéligibilité immédiate des élus condamnés : les positions des candidats 2027',
     seoDescription: `Exécution provisoire, inéligibilité des élus condamnés : que pensent les ${candidatesCount} candidats à la présidentielle 2027 ?`,
   },
+  'question-2027-num-02': {
+    slug: 'interdiction-reseaux-sociaux-mineurs-15-ans',
+    seoTitle: 'Réseaux sociaux interdits aux mineurs de 15 ans : les positions des candidats 2027',
+    seoDescription: `Réseaux sociaux et écrans chez les jeunes : comparez les positions des ${candidatesCount} candidats à la présidentielle 2027.`,
+  },
 };
 
 // Also auto-generate slugs for all remaining questions


### PR DESCRIPTION
## Pourquoi ce sujet

Le 21 juillet 2026, le Parlement a définitivement adopté la loi interdisant les réseaux sociaux aux moins de 15 ans (279 voix pour, 81 contre à l'Assemblée) — la France devient le premier pays d'Europe à le faire. Sujet très couvert cette semaine (franceinfo, Le Club des Juristes, Public Sénat, Touteleurope, LCP…), pas encore traité sur le blog, et substantiel politiquement : le vote a réuni majorité + droite + RN, mais LFI a voté contre et le PS s'est abstenu en menaçant de saisir le Conseil constitutionnel — une vraie ligne de fracture, pas un simple consensus de façade.

**Bonne nouvelle pour la portée des changements** : le sujet correspond exactement à une question déjà existante du quiz (`question-2027-num-02` — thème *Numérique et IA* — « Les réseaux sociaux et les écrans chez les jeunes, ça vous inquiète ? »), pour laquelle les 26 candidats ont déjà une réponse enregistrée. **Aucune nouvelle question n'a donc été ajoutée** — voir "Changements au quiz" ci-dessous.

### Sujets écartés
- **Sécheresse / loi d'urgence agricole** : déjà couvert par l'article du 20 juillet.
- **Aide à mourir** : déjà couvert par l'article du 18 juillet.
- **Affaire Lyhanna** (disparition et meurtre d'une fillette de 11 ans, dysfonctionnements judiciaires révélés) : très suivie médiatiquement, mais reste un fait divers judiciaire sans ligne de clivage politique claire entre candidats à ce stade — écarté par prudence éditoriale.
- **Budget 2027 / taxe Zucman** : dossier en cours mais pas d'événement "chaud" cette semaine précise (discours de Lecornu, pas de vote).

## Changements au quiz

**Aucune nouvelle question ajoutée.** Le sujet correspond à `question-2027-num-02` (déjà dans les 3 `quizz-2027.json`, déjà répondue par les 26 candidats dans les 3 `candidates-answers.json`).

Seul changement quiz-adjacent : ajout d'une entrée dans `hotTopicSlugs` (`app-tanstack/src/utils/seo.ts` uniquement, fichier non dupliqué) pour donner à cette question sa propre page SEO :
```
'question-2027-num-02': {
  slug: 'interdiction-reseaux-sociaux-mineurs-15-ans',
  seoTitle: 'Réseaux sociaux interdits aux mineurs de 15 ans : les positions des candidats 2027',
  seoDescription: `Réseaux sociaux et écrans chez les jeunes : comparez les positions des ${candidatesCount} candidats à la présidentielle 2027.`,
}
```

## Sources consultées
- [Assemblée nationale — adoption de la PPL réseaux sociaux/mineurs](``https://www.assemblee-nationale.fr/dyn/actualites-accueil-hub/proposition-de-loi-visant-a-proteger-les-mineurs-des-risques-auxquels-les-expose-l-utilisation-des-reseaux-sociaux-adoption)``
- ``[Sénat — accord en CMP le 20 juillet 2026 sur l'âge minimal](https://www.senat.fr/salle-de-presse/communiques-de-presse/presse/20-07-2026/la-cmp-sur-la-ppl-visant-a-proteger-les-mineurs-des-risques-des-reseaux-sociaux-parvient-a-un-accord-sur-un-dispositif-de-fixation-dun-age-minimal.html)``
- [LCP — ce que contient la loi définitivement adoptée](``https://lcp.fr/actualites/interdiction-des-reseaux-sociaux-aux-moins-de-15-ans-ce-que-contient-la-loi-qui-vient-d``)
- [Orange/AFP — adoption définitive, 279 voix pour / 81 contre](``https://actu.orange.fr/france/le-parlement-adopte-definitivement-la-loi-interdisant-les-reseaux-sociaux-aux-mineurs-de-moins-de-15-ans-magic-CNT000002qCDq3.html)``
- [Touteleurope — première en Europe, casse-tête avec le droit européen](``https://www.touteleurope.eu/societe/les-deputes-et-senateurs-francais-approuvent-l-interdiction-de-l-acces-aux-reseaux-sociaux-pour-les-moins-de-15-ans-une-premiere-en-europe/)``
- ``[Le Club des Juristes — obstacles techniques et droit européen](https://droit.developpez.com/actu/385387/Le-Parlement-francais-enterine-l-interdiction-des-reseaux-sociaux-aux-moins-de-15-ans-mais-le-texte-porte-par-Emmanuel-Macron-se-heurte-a-des-obstacles-techniques-majeurs-et-au-droit-europeen/)``
- [Public Sénat — une loi impossible à appliquer ? (étude Melbourne sur l'Australie, PS et Conseil constitutionnel)](``https://www.publicsenat.fr/actualites/politique/interdiction-des-reseaux-sociaux-aux-moins-de-15-ans-une-loi-impossible-a-appliquer``)
- Vote du 21 juillet (répartition par groupe : LFI seul contre, PS abstention, RN au bloc central pour) : recoupé sur plusieurs articles de presse de la semaine du 21 juillet 2026.
- Origine de la mesure (annonce Macron le 10 juin 2025 après le meurtre d'une surveillante à Nogent-sur-Seine) : sources presse concordantes.

⚠️ Je n'ai pas trouvé de date fiable et cohérente pour la première lecture à l'Assemblée (sources contradictoires : "27 janvier" vs "26 janvier" 2026) — je l'ai volontairement omise de la chronologie de l'article plutôt que de citer un chiffre non vérifié. À vérifier si vous voulez la préciser.

## Positions des candidats — pour vérification rapide

Toutes les positions viennent de `question-2027-num-02`, **déjà dans la base candidats** (donc "quiz data" pour tout le monde). La seule couche ajoutée dans l'article est la mention du **vote réel du 21 juillet** pour les partis représentés au Parlement — à vérifier en priorité si vous doutez d'un candidat.

| Candidat | Position quiz | Nuance ajoutée (vote du 21/07, sourcée) |
|---|---|---|
| Marine Le Pen (RN) | Interdiction stricte avant 16 ans | **Sourcé** — RN a voté pour |
| Gabriel Attal (Renaissance) | Interdiction stricte avant 16 ans | **Sourcé** — majorité présidentielle a voté pour |
| Gérald Darmanin | Interdiction stricte avant 16 ans | Quiz data uniquement |
| Bruno Retailleau (LR) | Interdiction stricte avant 16 ans | **Sourcé** — LR a voté pour |
| Éric Zemmour (Reconquête) | Interdiction stricte avant 16 ans | Quiz data (non représenté au Parlement) |
| Nicolas Dupont-Aignan (DLF) | Interdiction stricte avant 16 ans | Quiz data (non représenté au Parlement) |
| Marine Tondelier (Écologistes) | Interdiction stricte avant 16 ans | Quiz data uniquement |
| Jean-Luc Mélenchon (LFI) | Régulation forte, pas d'interdiction générale | **Sourcé** — groupe LFI a voté CONTRE ce texte précis (nuance explicitement expliquée dans l'article) |
| Clémentine Autain | Régulation forte | **Sourcé** — alignée LFI, vote contre |
| François Ruffin | Régulation forte | **Sourcé** — proche ligne LFI |
| Fabien Roussel (PCF) | Régulation forte | Quiz data uniquement |
| Raphaël Glucksmann (Place Publique) | Régulation forte | **Sourcé** — camp PS, abstention + menace de saisine du Conseil constitutionnel |
| Jérôme Guedj (PS) | Régulation forte | **Sourcé** — PS abstention + saisine CC |
| François Hollande | Régulation forte | Estimé — ligne proche PS, pas de déclaration individuelle trouvée cette semaine |
| Bernard Cazeneuve | Régulation forte | Estimé — ligne proche PS, pas de déclaration individuelle trouvée |
| Édouard Philippe (Horizons) | Régulation forte | Quiz data uniquement |
| Laurent Wauquiez (LR) | Régulation forte | Quiz data uniquement (LR est divisé dans le quiz : Wauquiez ≠ Retailleau) |
| Xavier Bertrand | Régulation forte | Quiz data uniquement |
| François Bayrou (MoDem) | Régulation forte | Quiz data uniquement |
| Dominique de Villepin | Régulation forte | Quiz data uniquement |
| Nathalie Arthaud (LO) | Régulation forte | Quiz data uniquement |
| François Asselineau (UPR) | Régulation forte | Quiz data uniquement |
| Delphine Batho (Génération Écologie) | Régulation forte | Quiz data uniquement |
| Juan Branco | Régulation forte | Quiz data uniquement |
| Patrick Sébastien | Régulation forte | Quiz data uniquement |
| David Lisnard | Aux parents de gérer, pas à l'État | Quiz data uniquement |

**À vérifier en priorité** : les deux lignes "Estimé" (Hollande, Cazeneuve) — je n'ai pas trouvé de prise de position individuelle cette semaine, seulement une cohérence avec la ligne PS. Le reste s'appuie sur des réponses déjà présentes dans la base ou sur des votes de groupe parlementaire sourcés.

## Validation
- `cd app-tanstack && npm install && npm run typecheck` : aucune erreur nouvelle introduite (les 4 erreurs `@prisma/client`/`express` viennent de `api-express` sans `node_modules` installés, préexistantes, confirmées identiques avant/après ce diff via `git stash`).
- Pas de modification des 3 `quizz-2027.json` ni des 3 `candidates-answers.json` (aucune nouvelle question).
- Pas de régénération du sitemap, aucun accès à la base de données.


---
_Generated by [Claude Code](https://claude.ai/code/session_012MZMevPc34khTZz2XpM7HF)_