### PR TITLE
blog: Loi Ripost sur la sécurité du quotidien : tout comprendre et les positions des candidats + new question

### DIFF
--- a/api-express/src/shared/candidates-answers.json
+++ b/api-express/src/shared/candidates-answers.json
@@ -395,6 +395,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -1065,6 +1070,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 0
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -1739,6 +1749,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -2409,6 +2424,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -3083,6 +3103,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 0
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 2
@@ -3753,6 +3778,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 3
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -4427,6 +4457,11 @@
         "answerIndex": 3
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 2
@@ -5097,6 +5132,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -5771,6 +5811,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -6441,6 +6486,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -7115,6 +7165,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -7785,6 +7840,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -8459,6 +8519,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 0
@@ -9131,6 +9196,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -9800,6 +9870,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
         "answerIndex": 1
       },
       {
@@ -10475,6 +10550,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 2
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -11145,6 +11225,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -11819,6 +11904,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -12489,6 +12579,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 3
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -13163,6 +13258,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -13833,6 +13933,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 0
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -14507,6 +14612,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -15179,6 +15289,11 @@
         "answerIndex": 3
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 0
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -15849,6 +15964,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 2
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -16728,6 +16848,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-union-europeenne-2027",
         "questionId": "question-2027-ue-01",
         "answerIndex": 1
@@ -17293,6 +17418,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
       },
       {
         "themeId": "theme-2027-gouvernance",

--- a/api-express/src/shared/candidates-answers/Bernard Cazeneuve.txt
+++ b/api-express/src/shared/candidates-answers/Bernard Cazeneuve.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [0] Il faut accompagner et aider les familles pour prévenir la récidive
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[2] Sanctionner ces nuisances tout en renforçant en parallèle la prévention et la médiation locale
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Bruno Retailleau.txt
+++ b/api-express/src/shared/candidates-answers/Bruno Retailleau.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [3] Il faut expulser des logements sociaux les familles de mineurs multirécidivistes
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[0] Durcir encore les sanctions : peines de prison systématiques, confiscations immédiates, fermetures administratives
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Clémentine Autain.txt
+++ b/api-express/src/shared/candidates-answers/Clémentine Autain.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [0] Il faut accompagner et aider les familles pour prévenir la récidive
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/David Lisnard.txt
+++ b/api-express/src/shared/candidates-answers/David Lisnard.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [2] Il faut responsabiliser les parents : suspendre les allocations familiales en cas de délinquance de leurs enfants
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Delphine Batho.txt
+++ b/api-express/src/shared/candidates-answers/Delphine Batho.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [0] Il faut accompagner et aider les familles pour prévenir la récidive
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Dominique de Villepin.txt
+++ b/api-express/src/shared/candidates-answers/Dominique de Villepin.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [1] Il y a déjà des dispositifs en place, pas besoin d'en rajouter
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[2] Sanctionner ces nuisances tout en renforçant en parallèle la prévention et la médiation locale
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Fabien Roussel.txt
+++ b/api-express/src/shared/candidates-answers/Fabien Roussel.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [0] Il faut accompagner et aider les familles pour prévenir la récidive
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[3] Privilégier la prévention et les moyens humains (éducateurs, police de proximité) plutôt que de nouveaux délits
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/François Asselineau.txt
+++ b/api-express/src/shared/candidates-answers/François Asselineau.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [2] Il faut responsabiliser les parents : suspendre les allocations familiales en cas de délinquance de leurs enfants
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[0] Durcir encore les sanctions : peines de prison systématiques, confiscations immédiates, fermetures administratives
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/François Bayrou.txt
+++ b/api-express/src/shared/candidates-answers/François Bayrou.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [1] Il y a déjà des dispositifs en place, pas besoin d'en rajouter
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/François Hollande.txt
+++ b/api-express/src/shared/candidates-answers/François Hollande.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [0] Il faut accompagner et aider les familles pour prévenir la récidive
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[3] Privilégier la prévention et les moyens humains (éducateurs, police de proximité) plutôt que de nouveaux délits
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/François Ruffin.txt
+++ b/api-express/src/shared/candidates-answers/François Ruffin.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [0] Il faut accompagner et aider les familles pour prévenir la récidive
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Gabriel Attal.txt
+++ b/api-express/src/shared/candidates-answers/Gabriel Attal.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [2] Il faut responsabiliser les parents : suspendre les allocations familiales en cas de délinquance de leurs enfants
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Gérald Darmanin.txt
+++ b/api-express/src/shared/candidates-answers/Gérald Darmanin.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [3] Il faut expulser des logements sociaux les familles de mineurs multirécidivistes
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Jean-Luc Mélenchon.txt
+++ b/api-express/src/shared/candidates-answers/Jean-Luc Mélenchon.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [0] Il faut accompagner et aider les familles pour prévenir la récidive
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Juan Branco.txt
+++ b/api-express/src/shared/candidates-answers/Juan Branco.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [0] Il faut accompagner et aider les familles pour prévenir la récidive
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Jérôme Guedj.txt
+++ b/api-express/src/shared/candidates-answers/Jérôme Guedj.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [0] Il faut accompagner et aider les familles pour prévenir la récidive
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[3] Privilégier la prévention et les moyens humains (éducateurs, police de proximité) plutôt que de nouveaux délits
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Laurent Wauquiez.txt
+++ b/api-express/src/shared/candidates-answers/Laurent Wauquiez.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [2] Il faut responsabiliser les parents : suspendre les allocations familiales en cas de délinquance de leurs enfants
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Marine Le Pen.txt
+++ b/api-express/src/shared/candidates-answers/Marine Le Pen.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [3] Il faut expulser des logements sociaux les familles de mineurs multirécidivistes
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Marine Tondelier.txt
+++ b/api-express/src/shared/candidates-answers/Marine Tondelier.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [0] Il faut accompagner et aider les familles pour prévenir la récidive
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Nathalie Arthaud.txt
+++ b/api-express/src/shared/candidates-answers/Nathalie Arthaud.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [0] Il faut accompagner et aider les familles pour prévenir la récidive
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Nicolas Dupont-Aignan.txt
+++ b/api-express/src/shared/candidates-answers/Nicolas Dupont-Aignan.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [2] Il faut responsabiliser les parents : suspendre les allocations familiales en cas de délinquance de leurs enfants
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[0] Durcir encore les sanctions : peines de prison systématiques, confiscations immédiates, fermetures administratives
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Patrick Sébastien.txt
+++ b/api-express/src/shared/candidates-answers/Patrick Sébastien.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [2] Il faut responsabiliser les parents : suspendre les allocations familiales en cas de délinquance de leurs enfants
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Raphaël Glucksmann.txt
+++ b/api-express/src/shared/candidates-answers/Raphaël Glucksmann.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [0] Il faut accompagner et aider les familles pour prévenir la récidive
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[3] Privilégier la prévention et les moyens humains (éducateurs, police de proximité) plutôt que de nouveaux délits
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Xavier Bertrand.txt
+++ b/api-express/src/shared/candidates-answers/Xavier Bertrand.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [2] Il faut responsabiliser les parents : suspendre les allocations familiales en cas de délinquance de leurs enfants
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Édouard Philippe.txt
+++ b/api-express/src/shared/candidates-answers/Édouard Philippe.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [2] Il faut responsabiliser les parents : suspendre les allocations familiales en cas de délinquance de leurs enfants
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Éric Zemmour.txt
+++ b/api-express/src/shared/candidates-answers/Éric Zemmour.txt
@@ -298,6 +298,9 @@ question-2027-pol-07: Que pensez-vous du cannabis et de sa légalisation ?
 question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des familles de délinquants ?
 [3] Il faut expulser des logements sociaux les familles de mineurs multirécidivistes
 
+question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
+[0] Durcir encore les sanctions : peines de prison systématiques, confiscations immédiates, fermetures administratives
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/quizz-2027.json
+++ b/api-express/src/shared/quizz-2027.json
@@ -1674,6 +1674,27 @@
           [0, 0, 3, 5, 0],
           [0, 0, 0, 0, 0]
         ]
+      },
+      {
+        "_id": "question-2027-pol-09",
+        "fr": "Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?",
+        "help": "https://fr.wikipedia.org/wiki/Rod%C3%A9o_urbain",
+        "answers": [
+          "Durcir encore les sanctions : peines de prison systématiques, confiscations immédiates, fermetures administratives",
+          "Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote",
+          "Sanctionner ces nuisances tout en renforçant en parallèle la prévention et la médiation locale",
+          "Privilégier la prévention et les moyens humains (éducateurs, police de proximité) plutôt que de nouveaux délits",
+          "S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème",
+          "Ça ne m'intéresse pas / Je n'ai pas d'avis"
+        ],
+        "scores": [
+          [5, 3, 1, 0, 0, 0],
+          [3, 5, 3, 1, 0, 0],
+          [1, 3, 5, 3, 1, 0],
+          [0, 1, 3, 5, 3, 0],
+          [0, 0, 1, 3, 5, 0],
+          [0, 0, 0, 0, 0, 0]
+        ]
       }
     ]
   },

--- a/app-tanstack/src/content/articles.ts
+++ b/app-tanstack/src/content/articles.ts
@@ -1297,4 +1297,131 @@ export const articles: Article[] = [
       ],
     },
   },
+  {
+    slug: 'loi-ripost-securite-quotidien-france-candidats-2027',
+    title: `Loi Ripost sur la sécurité du quotidien : tout comprendre et les positions des ${candidatesCount} candidats à la présidentielle 2027`,
+    excerpt:
+      "Rodéos motorisés, free parties, protoxyde d'azote : la loi Ripost a été adoptée définitivement le 21 juillet 2026, après un vote qui a opposé le Rassemblement national et la majorité gouvernementale à une gauche unie. Que contient le texte, pourquoi divise-t-il, et où se situent les candidats à la présidentielle 2027 ?",
+    date: '2026-07-27',
+    tag: 'Analyse',
+    content: `
+<p>Le Parlement a adopté définitivement la loi Ripost le 21 juillet 2026, par 351 voix contre 179. Le texte crée de nouveaux délits pour les rodéos motorisés, les free parties et l'usage de protoxyde d'azote, renforce des amendes existantes et ouvre la voie à des fermetures administratives. Une semaine plus tôt, en première lecture, le même clivage était déjà net : le Rassemblement national et la majorité gouvernementale ont voté pour, la gauche unie a voté contre. Sur les ${candidatesCount} candidats à la présidentielle 2027, aucun ne nie le problème des nuisances du quotidien, mais leurs réponses divergent nettement sur la méthode.</p>
+
+<h2>La loi Ripost, c'est quoi ?</h2>
+<p>La loi Ripost, ou « projet de loi visant à offrir des réponses immédiates aux phénomènes troublant l'ordre public, la sécurité et la tranquillité de nos concitoyens », vise la délinquance du quotidien : rodéos motorisés, free parties, mésusage du protoxyde d'azote et des feux d'artifice. Le texte a été ébauché par Bruno Retailleau lorsqu'il était ministre de l'Intérieur, avant son départ du gouvernement le 12 octobre 2025. Son successeur Place Beauvau, Laurent Nuñez, l'a repris et porté jusqu'à son adoption, en le présentant comme un « choc d'autorité » et un « choc d'efficacité » sur la sécurité du quotidien.</p>
+
+<h2>Chronologie</h2>
+<ul>
+<li><strong>12 octobre 2025</strong> : Bruno Retailleau quitte le ministère de l'Intérieur ; Laurent Nuñez lui succède et reprend le texte qu'il avait ébauché.</li>
+<li><strong>18-20 mai 2026</strong> : le Sénat examine le texte en première lecture et l'adopte à l'issue d'un vote solennel.</li>
+<li><strong>7-10 juillet 2026</strong> : l'Assemblée nationale examine le texte en première lecture, sous la houlette du ministre de l'Intérieur Laurent Nuñez.</li>
+<li><strong>15 juillet 2026</strong> : première adoption à l'Assemblée nationale, par 366 voix contre 182. Le Rassemblement national vote avec la majorité gouvernementale ; la gauche unie vote contre.</li>
+<li><strong>16 juillet 2026</strong> : le Syndicat de la magistrature organise une conférence de presse commune avec La France insoumise, Amnesty International et la militante Assa Traoré pour dénoncer un texte qu'il juge liberticide. Bruno Retailleau accuse le syndicat de connivence avec l'extrême gauche ; la Ligue des libertés et l'Institut pour la justice demandent une saisine à son sujet.</li>
+<li><strong>20 juillet 2026</strong> : députés et sénateurs trouvent un compromis en commission mixte paritaire (CMP), qui rétablit le relèvement de l'amende forfaitaire délictuelle pour usage de stupéfiants et la conservation des enregistrements de vidéosurveillance dans les locaux de garde à vue, deux mesures supprimées lors de l'examen à l'Assemblée.</li>
+<li><strong>21 juillet 2026</strong> : adoption définitive du texte issu de la CMP, par 351 voix contre 179.</li>
+</ul>
+
+<h2>Que contient la loi Ripost ?</h2>
+<p>Le texte crée ou durcit plusieurs infractions :</p>
+<ul>
+<li>Un délit d'<strong>organisation illégale d'un rassemblement musical</strong> (free party), puni de deux ans de prison et 30 000 euros d'amende, avec confiscation du matériel de sonorisation et saisie du véhicule ayant servi à le transporter ; le conducteur risque en plus trois ans d'annulation de permis.</li>
+<li>L'extension de l'<strong>amende forfaitaire délictuelle</strong> aux rodéos motorisés, pour sanctionner plus vite sans passer systématiquement par un tribunal.</li>
+<li>Un délit d'<strong>inhalation de protoxyde d'azote</strong>, puni d'un an de prison et 3 750 euros d'amende (ou d'une amende forfaitaire de 500 euros), et jusqu'à trois ans de prison et 9 000 euros d'amende en cas de conduite sous son emprise. La vente aux particuliers est interdite, mais l'entrée en vigueur de cette interdiction est reportée au 1ᵉʳ février 2027 pour respecter le droit européen.</li>
+<li>Jusqu'à trois ans de prison et 45 000 euros d'amende pour la détention ou le transport de mortiers d'artifice sans motif légitime, et une procédure de fermeture administrative pour les commerces qui en vendent illégalement.</li>
+</ul>
+
+<h2>Pourquoi la loi Ripost divise</h2>
+
+<h3>1. Choc d'autorité ou inflation pénale ?</h3>
+<p>Pour ses défenseurs, la loi Ripost répond à une demande sociale réelle sur des nuisances qui dégradent le quotidien de nombreux quartiers et zones rurales. Le Syndicat de la magistrature y voit au contraire un texte « liberticide », « répressif » et « gestionnaire », qui multiplie les délits sans s'attaquer aux causes des troubles à l'ordre public.</p>
+
+<h3>2. Une alliance qui a fait des vagues</h3>
+<p>La conférence de presse commune du 16 juillet entre le Syndicat de la magistrature, La France insoumise, Amnesty International et Assa Traoré a provoqué une vive réaction à droite. Le député LFI Thomas Portes a qualifié le texte de sorti « du programme de Jean-Marie Le Pen ». Bruno Retailleau a dénoncé une connivence entre magistrats et extrême gauche, tandis que la Ligue des libertés et l'Institut pour la justice ont demandé une saisine visant le syndicat.</p>
+
+<h3>3. Un texte freiné par le droit européen</h3>
+<p>L'interdiction de vente de protoxyde d'azote aux particuliers ne peut entrer en vigueur avant le 1ᵉʳ février 2027, le temps de respecter les procédures de notification à la Commission européenne. En attendant cette date, seule la détention ou le transport d'une quantité dépassant un certain seuil est sanctionné.</p>
+
+<h2>Les positions des ${candidatesCount} candidats à la présidentielle 2027</h2>
+<p>Sur la question <a href="/question-politique/loi-ripost-securite-quotidien-france">« Comment répondre aux nuisances du quotidien ? »</a> du <a href="/theme/police-justice-et-securite">Quizz du Berger</a>, les ${candidatesCount} candidats se répartissent en quatre familles.</p>
+
+<h3>Famille 1 — Fermeté : soutenir la loi Ripost, voire durcir encore</h3>
+<p>Ces candidats ou leurs partis ont voté pour la loi Ripost, ou défendent une ligne au moins aussi ferme.</p>
+<ul>
+<li><a href="/candidat/bruno-retailleau">Bruno Retailleau</a> (LR) — Auteur de la version initiale du texte comme ministre de l'Intérieur, avant son départ du gouvernement le 12 octobre 2025 ; sa ligne, plus dure que la version finalement votée, laisse penser qu'il aurait souhaité aller plus loin.</li>
+<li><a href="/candidat/eric-zemmour">Éric Zemmour</a> (Reconquête) — Sa ligne sécuritaire constante laisse penser qu'il jugerait la loi Ripost insuffisante face aux nuisances du quotidien.</li>
+<li><a href="/candidat/nicolas-dupont-aignan">Nicolas Dupont-Aignan</a> (DLF) — Ligne souverainiste proche du RN sur la sécurité, favorable à une fermeté accrue.</li>
+<li><a href="/candidat/francois-asselineau">François Asselineau</a> (UPR) — Ligne sécuritaire souverainiste, favorable à un durcissement des sanctions.</li>
+<li><a href="/candidat/marine-le-pen">Marine Le Pen</a> (RN) — Le RN a voté pour la loi Ripost, en première lecture comme à l'adoption définitive.</li>
+<li><a href="/candidat/gabriel-attal">Gabriel Attal</a> (Renaissance) — Le texte a été porté par le gouvernement dont son parti est le pilier, avec le vote de la majorité présidentielle.</li>
+<li><a href="/candidat/gerald-darmanin">Gérald Darmanin</a> — Issu de la majorité qui a porté le texte défendu par le ministre de l'Intérieur Laurent Nuñez.</li>
+<li><a href="/candidat/laurent-wauquiez">Laurent Wauquiez</a> (LR) — Le groupe LR a voté pour la loi Ripost à l'Assemblée nationale.</li>
+<li><a href="/candidat/xavier-bertrand">Xavier Bertrand</a> — Ligne proche de celle de Wauquiez, le groupe LR ayant voté pour le texte.</li>
+<li><a href="/candidat/david-lisnard">David Lisnard</a> — Maire favorable à la fermeté sur l'ordre public, sa ligne laisse penser qu'il aurait voté pour le texte.</li>
+<li><a href="/candidat/edouard-philippe">Édouard Philippe</a> (Horizons) — Horizons est un parti de la majorité gouvernementale qui a porté et voté le texte.</li>
+<li><a href="/candidat/francois-bayrou">François Bayrou</a> (MoDem) — Le MoDem, partenaire de la majorité gouvernementale, a très probablement voté pour le texte, même si sa doctrine pénale personnelle est plus mesurée.</li>
+<li><a href="/candidat/patrick-sebastien">Patrick Sébastien</a> — Sa ligne populiste sur les nuisances du quotidien laisse penser à un soutien à une réponse ferme.</li>
+</ul>
+
+<h3>Famille 2 — Sanctionner sans renoncer à la prévention</h3>
+<p>Ces deux candidats n'ont pas de siège à l'Assemblée nationale et n'ont donc pas voté le texte, mais leur ligne cherche un équilibre entre sanction et prévention plutôt qu'un camp tranché.</p>
+<ul>
+<li><a href="/candidat/bernard-cazeneuve">Bernard Cazeneuve</a> — Ancien ministre de l'Intérieur à la ligne sécuritaire mesurée, sa position laisse penser à un soutien aux sanctions couplé à des moyens de prévention.</li>
+<li><a href="/candidat/dominique-de-villepin">Dominique de Villepin</a> — Ligne institutionnelle d'ordre mesuré, entre fermeté et prévention.</li>
+</ul>
+
+<h3>Famille 3 — Prévention prioritaire, contre le texte tel qu'adopté</h3>
+<p>Ces candidats ou leurs partis ont voté contre la loi Ripost au sein du bloc de gauche uni, en défendant une priorité à la prévention plutôt qu'à de nouveaux délits.</p>
+<ul>
+<li><a href="/candidat/jerome-guedj">Jérôme Guedj</a> (PS) — Le groupe socialiste a voté contre la loi Ripost.</li>
+<li><a href="/candidat/francois-hollande">François Hollande</a> — Ligne proche du PS, dont le groupe a voté contre le texte.</li>
+<li><a href="/candidat/raphael-glucksmann">Raphaël Glucksmann</a> (Place Publique) — Sa famille politique a voté contre la loi Ripost au sein du bloc de gauche uni.</li>
+<li><a href="/candidat/fabien-roussel">Fabien Roussel</a> (PCF) — Le groupe communiste a voté contre le texte.</li>
+</ul>
+
+<h3>Famille 4 — Opposition frontale à l'inflation pénale</h3>
+<p>Ces candidats jugent la loi Ripost disproportionnée et inefficace face aux causes sociales des troubles à l'ordre public, une ligne proche de celle du Syndicat de la magistrature.</p>
+<ul>
+<li><a href="/candidat/jean-luc-melenchon">Jean-Luc Mélenchon</a> (LFI) — Son groupe a voté contre le texte ; le député LFI Thomas Portes l'a qualifié de sorti « du programme de Jean-Marie Le Pen ».</li>
+<li><a href="/candidat/clementine-autain">Clémentine Autain</a> — Alignée sur la ligne LFI, y compris le vote contre le texte.</li>
+<li><a href="/candidat/francois-ruffin">François Ruffin</a> — Proche de la ligne LFI d'opposition à ce texte.</li>
+<li><a href="/candidat/marine-tondelier">Marine Tondelier</a> (Les Écologistes) — Le groupe écologiste a voté contre la loi Ripost au sein du bloc de gauche uni.</li>
+<li><a href="/candidat/delphine-batho">Delphine Batho</a> (Génération Écologie) — Ligne écologiste proche de celle des Écologistes, qui ont voté contre le texte.</li>
+<li><a href="/candidat/nathalie-arthaud">Nathalie Arthaud</a> (LO) — Dénonce une réponse pénale qui ne s'attaque pas aux causes sociales du problème.</li>
+<li><a href="/candidat/juan-branco">Juan Branco</a> — Ligne radicale opposée à l'inflation pénale, proche de celle de LFI.</li>
+</ul>
+
+<h2>Arguments pour et arguments contre la loi Ripost</h2>
+<table>
+<tr><th>Arguments en faveur de la loi</th><th>Arguments contre, ou réservés</th></tr>
+<tr><td>Répond à une demande sociale réelle sur des nuisances qui dégradent la vie quotidienne dans de nombreux quartiers.</td><td>Le Syndicat de la magistrature juge le texte liberticide et gestionnaire, sans action sur les causes des troubles.</td></tr>
+<tr><td>Sanctions plus rapides grâce à l'extension de l'amende forfaitaire délictuelle, sans passer systématiquement par un tribunal.</td><td>Risque d'inflation pénale : de nouveaux délits s'ajoutent sans moyens supplémentaires pour les faire appliquer.</td></tr>
+<tr><td>Cible des nuisances concrètes et documentées : rodéos motorisés, free parties, protoxyde d'azote, mortiers d'artifice.</td><td>L'interdiction de vente du protoxyde d'azote ne peut entrer en vigueur avant février 2027, faute de compatibilité immédiate avec le droit européen.</td></tr>
+<tr><td>Adopté par une majorité parlementaire nette (351 voix contre 179 à l'adoption définitive).</td><td>Vote clivant : toute la gauche unie s'est opposée au texte.</td></tr>
+<tr><td>La commission mixte paritaire a rétabli la conservation des enregistrements de vidéosurveillance en garde à vue, utile aux enquêtes.</td><td>Cette même conservation inquiète les défenseurs des libertés individuelles.</td></tr>
+</table>
+
+<h2>Pour aller plus loin</h2>
+<p>La loi Ripost s'inscrit dans un débat plus large sur la sécurité et la justice pénale. Sur le Quizz du Berger, les thèmes et questions qui touchent à ces sujets :</p>
+<ul>
+<li><a href="/theme/police-justice-et-securite">Police, Justice et Sécurité</a> — violences policières, doctrine pénale, terrorisme, cannabis.</li>
+<li><a href="/question-politique/loi-ripost-securite-quotidien-france">Nuisances du quotidien</a> — la question complète et les réponses détaillées des ${candidatesCount} candidats.</li>
+</ul>
+
+<p><a href="/themes">→ Faire le quiz</a></p>
+`,
+    schema: {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: `Loi Ripost sur la sécurité du quotidien : tout comprendre et les positions des ${candidatesCount} candidats à la présidentielle 2027`,
+      description:
+        "Loi Ripost adoptée définitivement le 21 juillet 2026 : rodéos motorisés, free parties, protoxyde d'azote. Contenu du texte, chronologie et positions détaillées des candidats à la présidentielle 2027.",
+      author: { '@type': 'Person', name: 'Arnaud Ambroselli' },
+      datePublished: '2026-07-27',
+      about: [
+        { '@type': 'Thing', name: 'Loi Ripost' },
+        { '@type': 'Thing', name: 'Sécurité du quotidien' },
+        { '@type': 'Thing', name: 'Élection présidentielle française de 2027' },
+      ],
+    },
+  },
 ];

--- a/app-tanstack/src/shared/candidates-answers.json
+++ b/app-tanstack/src/shared/candidates-answers.json
@@ -395,6 +395,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -1065,6 +1070,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 0
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -1739,6 +1749,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -2409,6 +2424,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -3083,6 +3103,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 0
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 2
@@ -3753,6 +3778,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 3
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -4427,6 +4457,11 @@
         "answerIndex": 3
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 2
@@ -5097,6 +5132,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -5771,6 +5811,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -6441,6 +6486,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -7115,6 +7165,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -7785,6 +7840,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -8459,6 +8519,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 0
@@ -9131,6 +9196,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -9800,6 +9870,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
         "answerIndex": 1
       },
       {
@@ -10475,6 +10550,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 2
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -11145,6 +11225,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -11819,6 +11904,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -12489,6 +12579,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 3
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -13163,6 +13258,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -13833,6 +13933,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 0
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -14507,6 +14612,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -15179,6 +15289,11 @@
         "answerIndex": 3
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 0
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -15849,6 +15964,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 2
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -16728,6 +16848,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-union-europeenne-2027",
         "questionId": "question-2027-ue-01",
         "answerIndex": 1
@@ -17293,6 +17418,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
       },
       {
         "themeId": "theme-2027-gouvernance",

--- a/app-tanstack/src/shared/quizz-2027.json
+++ b/app-tanstack/src/shared/quizz-2027.json
@@ -1674,6 +1674,27 @@
           [0, 0, 3, 5, 0],
           [0, 0, 0, 0, 0]
         ]
+      },
+      {
+        "_id": "question-2027-pol-09",
+        "fr": "Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?",
+        "help": "https://fr.wikipedia.org/wiki/Rod%C3%A9o_urbain",
+        "answers": [
+          "Durcir encore les sanctions : peines de prison systématiques, confiscations immédiates, fermetures administratives",
+          "Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote",
+          "Sanctionner ces nuisances tout en renforçant en parallèle la prévention et la médiation locale",
+          "Privilégier la prévention et les moyens humains (éducateurs, police de proximité) plutôt que de nouveaux délits",
+          "S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème",
+          "Ça ne m'intéresse pas / Je n'ai pas d'avis"
+        ],
+        "scores": [
+          [5, 3, 1, 0, 0, 0],
+          [3, 5, 3, 1, 0, 0],
+          [1, 3, 5, 3, 1, 0],
+          [0, 1, 3, 5, 3, 0],
+          [0, 0, 1, 3, 5, 0],
+          [0, 0, 0, 0, 0, 0]
+        ]
       }
     ]
   },

--- a/app-tanstack/src/utils/seo.ts
+++ b/app-tanstack/src/utils/seo.ts
@@ -221,6 +221,11 @@ const hotTopicSlugs: Record<string, { slug: string; seoTitle: string; seoDescrip
     seoTitle: 'Réseaux sociaux interdits aux mineurs de 15 ans : les positions des candidats 2027',
     seoDescription: `Réseaux sociaux et écrans chez les jeunes : comparez les positions des ${candidatesCount} candidats à la présidentielle 2027.`,
   },
+  'question-2027-pol-09': {
+    slug: 'loi-ripost-securite-quotidien-france',
+    seoTitle: 'Loi Ripost et sécurité du quotidien : les positions des candidats 2027',
+    seoDescription: `Rodéos motorisés, free parties, protoxyde d'azote : comparez les positions des ${candidatesCount} candidats à la présidentielle 2027 sur la loi Ripost.`,
+  },
 };
 
 // Also auto-generate slugs for all remaining questions

--- a/expo/src/shared/candidates-answers.json
+++ b/expo/src/shared/candidates-answers.json
@@ -395,6 +395,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -1065,6 +1070,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 0
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -1739,6 +1749,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -2409,6 +2424,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -3083,6 +3103,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 0
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 2
@@ -3753,6 +3778,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 3
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -4427,6 +4457,11 @@
         "answerIndex": 3
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 2
@@ -5097,6 +5132,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -5771,6 +5811,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -6441,6 +6486,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -7115,6 +7165,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -7785,6 +7840,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -8459,6 +8519,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 0
@@ -9131,6 +9196,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -9800,6 +9870,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
         "answerIndex": 1
       },
       {
@@ -10475,6 +10550,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 2
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -11145,6 +11225,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -11819,6 +11904,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -12489,6 +12579,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 3
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -13163,6 +13258,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -13833,6 +13933,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 0
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -14507,6 +14612,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -15179,6 +15289,11 @@
         "answerIndex": 3
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 0
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -15849,6 +15964,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 2
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -16728,6 +16848,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-union-europeenne-2027",
         "questionId": "question-2027-ue-01",
         "answerIndex": 1
@@ -17293,6 +17418,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-08",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-09",
+        "answerIndex": 1
       },
       {
         "themeId": "theme-2027-gouvernance",

--- a/expo/src/shared/quizz-2027.json
+++ b/expo/src/shared/quizz-2027.json
@@ -4510,6 +4510,27 @@
             0
           ]
         ]
+      },
+      {
+        "_id": "question-2027-pol-09",
+        "fr": "Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?",
+        "help": "https://fr.wikipedia.org/wiki/Rod%C3%A9o_urbain",
+        "answers": [
+          "Durcir encore les sanctions : peines de prison systématiques, confiscations immédiates, fermetures administratives",
+          "Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote",
+          "Sanctionner ces nuisances tout en renforçant en parallèle la prévention et la médiation locale",
+          "Privilégier la prévention et les moyens humains (éducateurs, police de proximité) plutôt que de nouveaux délits",
+          "S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème",
+          "Ça ne m'intéresse pas / Je n'ai pas d'avis"
+        ],
+        "scores": [
+          [5, 3, 1, 0, 0, 0],
+          [3, 5, 3, 1, 0, 0],
+          [1, 3, 5, 3, 1, 0],
+          [0, 1, 3, 5, 3, 0],
+          [0, 0, 1, 3, 5, 0],
+          [0, 0, 0, 0, 0, 0]
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Pourquoi ce sujet

La loi Ripost (rodéos motorisés, free parties, protoxyde d'azote) a été adoptée définitivement le 21 juillet 2026 (351 voix pour, 179 contre), une semaine après une première lecture déjà clivante (366-182) : RN + majorité gouvernementale pour, gauche unie contre. Une conférence de presse commune Syndicat de la magistrature / LFI / Amnesty International / Assa Traoré le 16 juillet a provoqué une riposte à droite (Retailleau, Ligue des libertés, Institut pour la justice). C'est couvert par de nombreux médias cette semaine (franceinfo, LCP, Public Sénat, AEF, Le JDD, etc.), c'est un vrai clivage droite/gauche, et **aucune question existante du quiz ne couvre la "sécurité du quotidien"** (les questions pol-01 à pol-08 couvrent violences policières, sécurité perçue, justice, doctrine pénale générale, terrorisme, formation policière, cannabis, familles de délinquants — rien sur rodéos/free parties/nuisances sonores). J'ai donc ajouté une nouvelle question plutôt que de forcer l'article sur une question existante mal ajustée.

**Sujets envisagés et écartés :**
- **Loi sur l'aide à mourir** (adoptée définitivement le 15 juillet) — déjà couverte par l'article `loi-aide-a-mourir-france-candidats-2027` (daté du 18 juillet).
- **Loi d'urgence agricole / crise de l'eau / acétamipride** (adoptée le 20-21 juillet) — déjà couverte en détail par l'article `crise-eau-secheresse-france-candidats-2027` (daté du 20 juillet), y compris le volet pesticides.
- **Interdiction des réseaux sociaux aux moins de 15 ans** (adoptée le 21 juillet) — déjà couverte par l'article `interdiction-reseaux-sociaux-mineurs-france-candidats-2027` (daté du 23 juillet).
- **Actualité de la présidentielle elle-même** (déclarations de candidature, sondages, cote de popularité de Macron/Lecornu) — pas substantiel politiquement, plutôt du horse-race / fait divers.

## Sources consultées

- [LCP — Free parties, rodéos urbains, protoxyde d'azote : ce que la loi Ripost prévoit](``https://lcp.fr/actualites/free-parties-rodeos-urbains-protoxyde-d-azote-ce-que-la-loi-ripost-prevoit-la-fiche``)
- [LCP — Le Parlement adopte définitivement le projet de loi Ripost](``https://lcp.fr/actualites/protoxyde-d-azote-rodeos-urbains-free-parties-le-parlement-adopte-definitivement-le``)
- [franceinfo — Le Parlement adopte définitivement le projet de loi Ripost](``https://www.franceinfo.fr/politique/protoxyde-d-azote-rodeos-urbains-free-parties-le-parlement-adopte-definitivement-le-projet-de-loi-ripost-sur-la-tranquillite-publique_8117027.html)``
- ``[Assemblée nationale — Adoption en première lecture](https://www.assemblee-nationale.fr/dyn/actualites-accueil-hub/vote-solennel-sur-le-projet-de-loi-visant-a-offrir-des-reponses-immediates-aux-phenomenes-troublant-l-ordre-public-la-securite-et-la-tranquillite)``
- ``[Assemblée nationale — Examen du projet de loi](https://www.assemblee-nationale.fr/dyn/actualites-accueil-hub/examen-du-projet-de-loi-visant-a-offrir-des-reponses-immediates-aux-phenomenes-troublant-l-ordre-public-la-securite-et-la-tranquillite-de-nos-conc)``
- [Public Sénat — Ce que contient le texte du Sénat](``https://www.publicsenat.fr/actualites/parlementaire/projet-de-loi-ripost-contre-les-troubles-a-lordre-public-ce-que-contient-le-texte-du-senat``)
- [Public Sénat — Peine de prison votée au Sénat pour l'organisation d'une free party](https://www.publicsenat.fr/actualites/politique/loi-ripost-peine-de-prison-votee-au-senat-pour-lorganisation-dune-free-party)
- [Europe 1 — Le gouvernement reprend la main sur le texte avant le vote à l'Assemblée](``https://www.europe1.fr/politique/loi-ripost-le-gouvernement-reprend-la-main-sur-le-texte-avant-le-vote-a-lassemblee-970233``)
- [AEF Info — Le texte définitivement adopté après un accord en CMP](``https://www.aefinfo.fr/depeche/754544-projet-de-loi-ripost-le-texte-definitivement-adopte-par-le-parlement-apres-un-accord-en-commission-mixte-paritaire``)
- [24matins — Ce que les députés ont vraiment durci](https://www.24matins.fr/loi-ripost-ce-que-les-deputes-ont-vraiment-durci-1417294)
- [Orange Actu — Les mesures clés du projet de loi Ripost](``https://actu.orange.fr/politique/protoxyde-d-azote-rodeos-free-parties-les-mesures-cles-du-projet-de-loi-ripost-CNT000002qw9Ss.html``)
- [Le JDD — Le Syndicat de la magistrature dénonce la loi lors d'une conférence avec LFI](``https://www.lejdd.fr/politique/legitime-defense-des-policiers-le-syndicat-de-la-magistrature-denonce-la-loi-lors-dune-conference-avec-lfi-179271``)
- [Le JDD — La Ligue des libertés et l'Institut pour la justice attaquent le Syndicat de la magistrature](``https://www.lejdd.fr/Societe/info-jdd-conference-avec-lfi-la-ligue-des-libertes-attaque-le-syndicat-de-la-magistrature-et-interpelle-darmanin-179451``)
- [Révolution Permanente — Le Parlement adopte un nouvel arsenal sécuritaire porté par Nuñez](``https://www.revolutionpermanente.fr/Loi-RIPOST-le-Parlement-adopte-definitivement-un-nouvel-arsenal-securitaire-porte-par-Nunez``)

(Rejected-topic verification: franceinfo/touteleurope/info.gouv.fr coverage of the end-of-life law, agricultural emergency law and social-media-minors law, cross-checked against the three already-published articles listed above.)

## Nouvelle question ajoutée

Thème : `theme-2027-police` (Police, Justice et Sécurité) · `_id`: `question-2027-pol-09` · hot-topic slug : `loi-ripost-securite-quotidien-france`

**« Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ? »**

0. Durcir encore les sanctions : peines de prison systématiques, confiscations immédiates, fermetures administratives
1. Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
2. Sanctionner ces nuisances tout en renforçant en parallèle la prévention et la médiation locale
3. Privilégier la prévention et les moyens humains (éducateurs, police de proximité) plutôt que de nouveaux délits
4. S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
5. Ça ne m'intéresse pas / Je n'ai pas d'avis

Scores matrix (6×6, symmetric, diagonal=5, decreasing with ideological distance, "no opinion" row/col = 0):
```
[5, 3, 1, 0, 0, 0]
[3, 5, 3, 1, 0, 0]
[1, 3, 5, 3, 1, 0]
[0, 1, 3, 5, 3, 0]
[0, 0, 1, 3, 5, 0]
[0, 0, 0, 0, 0, 0]
```

Applied identically to the 3 `quizz-2027.json` files. Added `{ themeId, questionId, answerIndex }` for all 26 candidates in the 3 `candidates-answers.json` files, regenerated the `.txt` exports via `extract-all-answers.js`, and added the hot-topic SEO entry in `seo.ts`.

## Positions des candidats — à vérifier

Priorité aux votes de groupe réels quand ils existent ; sinon estimation à partir de la ligne du candidat (souvent en miroir de sa réponse existante à `question-2027-pol-04`, "doctrine pénale"). **Merci de vérifier en particulier les lignes marquées "estimé" avant de merger.**

| Candidat | Position (index) | Statut | Raisonnement |
|---|---|---|---|
| Marine Le Pen | 1 — soutenir la loi | Sourcé | Le RN a voté pour en 1ère lecture (366-182) et à l'adoption définitive (351-179). |
| Bruno Retailleau | 0 — durcir encore | Sourcé | A ébauché le texte comme ministre de l'Intérieur avant son départ le 12/10/2025 ; version initiale plus dure. |
| Éric Zemmour | 0 — durcir encore | Estimé | Pas de siège à l'Assemblée ; ligne Reconquête la plus dure, en miroir de pol-04 (tout-répressif). |
| Nicolas Dupont-Aignan | 0 — durcir encore | Estimé | Pas de siège ; ligne souverainiste proche RN, en miroir de pol-04. |
| François Asselineau | 0 — durcir encore | Estimé | Pas de siège ; ligne sécuritaire souverainiste, en miroir de pol-04. |
| Patrick Sébastien | 1 — soutenir la loi | Estimé, faible confiance | Aucune prise de position publique connue ; ligne populiste de fermeté supposée. |
| Gabriel Attal | 1 — soutenir la loi | Sourcé | Renaissance = majorité gouvernementale qui a porté et voté le texte. |
| Gérald Darmanin | 1 — soutenir la loi | Sourcé | Majorité gouvernementale, texte défendu par le ministre de l'Intérieur Nuñez. |
| Édouard Philippe | 1 — soutenir la loi | Sourcé | Horizons, partenaire de la majorité gouvernementale qui a voté le texte. |
| Laurent Wauquiez | 1 — soutenir la loi | Sourcé | Le groupe LR a voté pour. |
| Xavier Bertrand | 1 — soutenir la loi | Sourcé | Ligne LR, groupe qui a voté pour. |
| David Lisnard | 1 — soutenir la loi | Estimé | Pas de siège ; maire LR favorable à la fermeté, en miroir de pol-04. |
| François Bayrou | 1 — soutenir la loi | **Estimé, tension à vérifier** | MoDem = partenaire gouvernemental, probablement voté pour, mais sa réponse à pol-04 ("plutôt réinsertion") est plus mesurée — à confirmer. |
| Bernard Cazeneuve | 2 — équilibre | Estimé | Pas de siège ; ancien ministre de l'Intérieur, ligne sécuritaire mesurée. |
| Dominique de Villepin | 2 — équilibre | Estimé | Pas de siège ; ligne institutionnelle d'ordre mesuré. |
| Jérôme Guedj | 3 — prévention prioritaire | Sourcé | Le groupe PS a voté contre. |
| François Hollande | 3 — prévention prioritaire | Estimé | Pas de siège ; ligne proche du PS qui a voté contre. |
| Raphaël Glucksmann | 3 — prévention prioritaire | Sourcé | Sa famille politique (PS/Place Publique) a voté contre au sein de la gauche unie. |
| Fabien Roussel | 3 — prévention prioritaire | Sourcé | Le groupe PCF a voté contre. |
| Jean-Luc Mélenchon | 4 — opposition frontale | Sourcé | LFI a voté contre ; le député Thomas Portes a qualifié le texte de sorti « du programme de Jean-Marie Le Pen ». |
| Clémentine Autain | 4 — opposition frontale | Sourcé | Alignée sur le vote LFI contre le texte. |
| François Ruffin | 4 — opposition frontale | Estimé | Pas de siège ; proche de la ligne LFI d'opposition à ce texte précis. |
| Marine Tondelier | 4 — opposition frontale | Sourcé | Le groupe écologiste a voté contre au sein de la gauche unie. |
| Delphine Batho | 4 — opposition frontale | Estimé | Pas de siège ; ligne écologiste proche des Écologistes, qui ont voté contre. |
| Nathalie Arthaud | 4 — opposition frontale | Estimé | Pas de siège ; ligne LO anti-répression, en miroir de pol-04. |
| Juan Branco | 4 — opposition frontale | Estimé | Pas de siège ; ligne radicale proche de LFI, en miroir de pol-04. |

## Validation

- `npm install && npm run typecheck` (app-tanstack) : ✅ pass.
- Les 3 `quizz-2027.json` sont identiques (vérifié programmatiquement).
- Les 3 `candidates-answers.json` sont identiques et chaque candidat (26/26) a exactement une nouvelle entrée pour `question-2027-pol-09`.
- Matrice de scores carrée (6×6), vérifiée programmatiquement.
- Article relu contre `.claude/skills/no-ai-slop/eval.md` et `french.md` : pas de mots/patterns bannis détectés ; tirets cadratins de prose = 0 (seuls les séparateurs structurels des puces candidats et des titres "Famille N — …", cohérents avec tous les articles existants du site, utilisent le tiret).

---
_Generated by [Claude Code](https://claude.ai/code/session_012DtkUaRTrr8VTeyXXqso1h)_