### PR TITLE
blog: Présomption de légitime défense pour les policiers + new question

### DIFF
--- a/api-express/src/shared/candidates-answers.json
+++ b/api-express/src/shared/candidates-answers.json
@@ -405,6 +405,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -1085,6 +1090,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 2
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -1769,6 +1779,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -2448,6 +2463,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -3133,6 +3153,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 2
@@ -3812,6 +3837,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 3
       },
       {
@@ -4497,6 +4527,11 @@
         "answerIndex": 1
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 2
@@ -5176,6 +5211,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -5861,6 +5901,11 @@
         "answerIndex": 1
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -6540,6 +6585,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 4
       },
       {
@@ -7225,6 +7275,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -7907,6 +7962,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -8586,6 +8646,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -9271,6 +9336,11 @@
         "answerIndex": 1
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -9950,6 +10020,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -10635,6 +10710,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 2
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -11314,6 +11394,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -11999,6 +12084,11 @@
         "answerIndex": 3
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -12678,6 +12768,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 3
       },
       {
@@ -13363,6 +13458,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -14045,6 +14145,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -14724,6 +14829,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 3
       },
       {
@@ -15409,6 +15519,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 0
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -16089,6 +16204,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 3
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -16978,6 +17098,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-union-europeenne-2027",
         "questionId": "question-2027-ue-01",
         "answerIndex": 1
@@ -17553,6 +17678,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
         "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 2
       },
       {
         "themeId": "theme-2027-gouvernance",

--- a/api-express/src/shared/candidates-answers/Bernard Cazeneuve.txt
+++ b/api-express/src/shared/candidates-answers/Bernard Cazeneuve.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [2] Sanctionner ces nuisances tout en renforçant en parallèle la prévention et la médiation locale
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[2] Un juste milieu : mieux protéger juridiquement et matériellement les forces de l'ordre, sans renverser la charge de la preuve
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Bruno Retailleau.txt
+++ b/api-express/src/shared/candidates-answers/Bruno Retailleau.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [0] Durcir encore les sanctions : peines de prison systématiques, confiscations immédiates, fermetures administratives
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[1] Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Clémentine Autain.txt
+++ b/api-express/src/shared/candidates-answers/Clémentine Autain.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[4] Abroger ce texte, dénoncé comme un « permis de tuer » incompatible avec un État de droit
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/David Lisnard.txt
+++ b/api-express/src/shared/candidates-answers/David Lisnard.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[1] Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Delphine Batho.txt
+++ b/api-express/src/shared/candidates-answers/Delphine Batho.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[3] S'opposer à la présomption : le droit commun doit s'appliquer à tous, y compris aux forces de l'ordre, pour éviter tout risque d'impunité
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Dominique de Villepin.txt
+++ b/api-express/src/shared/candidates-answers/Dominique de Villepin.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [2] Sanctionner ces nuisances tout en renforçant en parallèle la prévention et la médiation locale
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[3] S'opposer à la présomption : le droit commun doit s'appliquer à tous, y compris aux forces de l'ordre, pour éviter tout risque d'impunité
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Fabien Roussel.txt
+++ b/api-express/src/shared/candidates-answers/Fabien Roussel.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [3] Privilégier la prévention et les moyens humains (éducateurs, police de proximité) plutôt que de nouveaux délits
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[3] S'opposer à la présomption : le droit commun doit s'appliquer à tous, y compris aux forces de l'ordre, pour éviter tout risque d'impunité
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/François Asselineau.txt
+++ b/api-express/src/shared/candidates-answers/François Asselineau.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [0] Durcir encore les sanctions : peines de prison systématiques, confiscations immédiates, fermetures administratives
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[2] Un juste milieu : mieux protéger juridiquement et matériellement les forces de l'ordre, sans renverser la charge de la preuve
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/François Bayrou.txt
+++ b/api-express/src/shared/candidates-answers/François Bayrou.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[1] Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/François Hollande.txt
+++ b/api-express/src/shared/candidates-answers/François Hollande.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [3] Privilégier la prévention et les moyens humains (éducateurs, police de proximité) plutôt que de nouveaux délits
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[3] S'opposer à la présomption : le droit commun doit s'appliquer à tous, y compris aux forces de l'ordre, pour éviter tout risque d'impunité
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/François Ruffin.txt
+++ b/api-express/src/shared/candidates-answers/François Ruffin.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[4] Abroger ce texte, dénoncé comme un « permis de tuer » incompatible avec un État de droit
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Gabriel Attal.txt
+++ b/api-express/src/shared/candidates-answers/Gabriel Attal.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[1] Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Gérald Darmanin.txt
+++ b/api-express/src/shared/candidates-answers/Gérald Darmanin.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[1] Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Jean-Luc Mélenchon.txt
+++ b/api-express/src/shared/candidates-answers/Jean-Luc Mélenchon.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[4] Abroger ce texte, dénoncé comme un « permis de tuer » incompatible avec un État de droit
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Juan Branco.txt
+++ b/api-express/src/shared/candidates-answers/Juan Branco.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[4] Abroger ce texte, dénoncé comme un « permis de tuer » incompatible avec un État de droit
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Jérôme Guedj.txt
+++ b/api-express/src/shared/candidates-answers/Jérôme Guedj.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [3] Privilégier la prévention et les moyens humains (éducateurs, police de proximité) plutôt que de nouveaux délits
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[3] S'opposer à la présomption : le droit commun doit s'appliquer à tous, y compris aux forces de l'ordre, pour éviter tout risque d'impunité
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Laurent Wauquiez.txt
+++ b/api-express/src/shared/candidates-answers/Laurent Wauquiez.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[1] Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Marine Le Pen.txt
+++ b/api-express/src/shared/candidates-answers/Marine Le Pen.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[1] Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Marine Tondelier.txt
+++ b/api-express/src/shared/candidates-answers/Marine Tondelier.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[3] S'opposer à la présomption : le droit commun doit s'appliquer à tous, y compris aux forces de l'ordre, pour éviter tout risque d'impunité
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Nathalie Arthaud.txt
+++ b/api-express/src/shared/candidates-answers/Nathalie Arthaud.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [4] S'opposer à cette inflation pénale, jugée disproportionnée et inefficace face aux causes sociales du problème
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[4] Abroger ce texte, dénoncé comme un « permis de tuer » incompatible avec un État de droit
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Nicolas Dupont-Aignan.txt
+++ b/api-express/src/shared/candidates-answers/Nicolas Dupont-Aignan.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [0] Durcir encore les sanctions : peines de prison systématiques, confiscations immédiates, fermetures administratives
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[1] Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Patrick Sébastien.txt
+++ b/api-express/src/shared/candidates-answers/Patrick Sébastien.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[2] Un juste milieu : mieux protéger juridiquement et matériellement les forces de l'ordre, sans renverser la charge de la preuve
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Raphaël Glucksmann.txt
+++ b/api-express/src/shared/candidates-answers/Raphaël Glucksmann.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [3] Privilégier la prévention et les moyens humains (éducateurs, police de proximité) plutôt que de nouveaux délits
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[3] S'opposer à la présomption : le droit commun doit s'appliquer à tous, y compris aux forces de l'ordre, pour éviter tout risque d'impunité
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Xavier Bertrand.txt
+++ b/api-express/src/shared/candidates-answers/Xavier Bertrand.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[1] Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Édouard Philippe.txt
+++ b/api-express/src/shared/candidates-answers/Édouard Philippe.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [1] Soutenir la loi Ripost telle qu'adoptée : nouveaux délits et amendes plus lourdes contre les rodéos, les free parties et le protoxyde d'azote
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[1] Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/candidates-answers/Éric Zemmour.txt
+++ b/api-express/src/shared/candidates-answers/Éric Zemmour.txt
@@ -304,6 +304,9 @@ question-2027-pol-08: Dans le cas des mineurs, que pensez-vous du traitement des
 question-2027-pol-09: Comment répondre aux nuisances du quotidien (rodéos motorisés, free parties, protoxyde d'azote) ?
 [0] Durcir encore les sanctions : peines de prison systématiques, confiscations immédiates, fermetures administratives
 
+question-2027-pol-10: Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?
+[0] Il faut aller plus loin qu'une présomption : une irresponsabilité pénale totale dès lors qu'un policier ou un gendarme utilise son arme en service
+
 
 Politique fiscale:
 

--- a/api-express/src/shared/quizz-2027.json
+++ b/api-express/src/shared/quizz-2027.json
@@ -1716,6 +1716,27 @@
           [0, 0, 1, 3, 5, 0],
           [0, 0, 0, 0, 0, 0]
         ]
+      },
+      {
+        "_id": "question-2027-pol-10",
+        "fr": "Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?",
+        "help": "https://www.assemblee-nationale.fr/dyn/actualites-accueil-hub/reconnaitre-une-presomption-de-legitime-defense-pour-les-forces-de-l-ordre-dans-l-exercice-de-leurs-fonctions-adoption-de-la-proposition-de-loi",
+        "answers": [
+          "Il faut aller plus loin qu'une présomption : une irresponsabilité pénale totale dès lors qu'un policier ou un gendarme utilise son arme en service",
+          "Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense",
+          "Un juste milieu : mieux protéger juridiquement et matériellement les forces de l'ordre, sans renverser la charge de la preuve",
+          "S'opposer à la présomption : le droit commun doit s'appliquer à tous, y compris aux forces de l'ordre, pour éviter tout risque d'impunité",
+          "Abroger ce texte, dénoncé comme un « permis de tuer » incompatible avec un État de droit",
+          "Ça ne m'intéresse pas / Je n'ai pas d'avis"
+        ],
+        "scores": [
+          [5, 3, 1, 0, 0, 0],
+          [3, 5, 3, 1, 0, 0],
+          [1, 3, 5, 3, 1, 0],
+          [0, 1, 3, 5, 3, 0],
+          [0, 0, 1, 3, 5, 0],
+          [0, 0, 0, 0, 0, 0]
+        ]
       }
     ]
   },

--- a/app-tanstack/src/content/articles.ts
+++ b/app-tanstack/src/content/articles.ts
@@ -1544,4 +1544,119 @@ export const articles: Article[] = [
       ],
     },
   },
+  {
+    slug: 'presomption-legitime-defense-policiers-france-candidats-2027',
+    title: `Présomption de légitime défense pour les policiers : tout comprendre et les positions des ${candidatesCount} candidats à la présidentielle 2027`,
+    excerpt:
+      "Adoptée à l'Assemblée nationale le 7 juillet 2026, la loi sur la présomption de légitime défense pour les forces de l'ordre inverse la charge de la preuve en cas de tir policier. Que contient le texte, pourquoi une pétition à 730 000 signatures a-t-elle été classée sans suite, et où se situent les candidats à la présidentielle 2027 ?",
+    date: '2026-08-03',
+    tag: 'Analyse',
+    content: `
+<p>L'Assemblée nationale a adopté le 7 juillet 2026, par 313 voix contre 199, une loi qui inverse la charge de la preuve en cas de tir des forces de l'ordre : ce sera à l'accusation de démontrer que le policier ou le gendarme n'a pas agi en légitime défense, et non l'inverse. Deux semaines plus tard, la commission des lois de l'Assemblée a classé sans suite une pétition contre le texte, pourtant créditée de plus de 730 000 signatures. Sur les ${candidatesCount} candidats à la présidentielle 2027, le clivage est net entre soutien à cette présomption et crainte d'une impunité policière.</p>
+
+<h2>La présomption de légitime défense : de quoi parle-t-on ?</h2>
+<p>En droit commun, la légitime défense (article 122-5 du code pénal) doit être prouvée par celui qui l'invoque, selon une jurisprudence constante de la chambre criminelle. Le texte porté par le député Éric Pauget (LR) crée une présomption spécifique aux policiers nationaux et aux gendarmes qui font usage de leur arme dans l'exercice de leurs fonctions, dans les conditions prévues par le code de la sécurité intérieure. Dans sa version initiale, la proposition visait aussi la police municipale ; celle-ci a finalement été exclue du texte adopté en première lecture.</p>
+
+<h2>Chronologie</h2>
+<ul>
+<li><strong>Juin 2026</strong> : Isam et Samia El Khalfaoui, père et tante de Souheil, 19 ans, tué par un tir de policier à Marseille en 2021, lancent avec le collectif Save (Stop State Violence) une pétition sur la plateforme de l'Assemblée nationale contre la proposition de loi.</li>
+<li><strong>7 juillet 2026</strong> : l'Assemblée nationale adopte le texte en première lecture, par 313 voix contre 199. Le gouvernement, la majorité présidentielle, Les Républicains et le Rassemblement national votent pour ; La France insoumise, le Parti socialiste, les Écologistes et le groupe Liot votent contre. Le texte est transmis le jour même au Sénat.</li>
+<li><strong>Nuit du 21 au 22 juillet 2026</strong> : la pétition, qui a dépassé les 500 000 signatures puis atteint plus de 730 000, est classée sans suite par la commission des lois de l'Assemblée nationale, par 35 voix contre 21. La majorité de la commission juge un débat en hémicycle « redondant » avec celui déjà tenu sur la proposition Pauget.</li>
+<li>Le texte reste, à ce stade, en attente d'examen au Sénat.</li>
+</ul>
+
+<h2>Pourquoi la présomption de légitime défense divise</h2>
+
+<h3>1. Protéger les policiers ou renverser dangereusement la charge de la preuve ?</h3>
+<p>Pour ceux qui l'ont votée, la présomption protège des agents qui risquent leur vie et subissent déjà de longues procédures judiciaires après chaque tir. Amnesty International parle au contraire d'un « permis de tuer » : renverser la charge de la preuve ferait peser sur la victime ou sa famille l'obligation de démontrer que le policier n'était pas en légitime défense, l'inverse du droit commun.</p>
+
+<h3>2. Une pétition massive mais classée sans suite</h3>
+<p>Depuis la création du droit de pétition à l'Assemblée nationale, un seul texte citoyen a donné lieu à un débat en hémicycle, celui contre la loi Duplomb sur l'agriculture. Avec plus de 730 000 signatures, largement au-dessus du seuil de 500 000, la pétition contre la présomption de légitime défense a connu un sort différent : la commission des lois a estimé qu'un débat serait redondant avec l'examen déjà mené sur la proposition Pauget.</p>
+
+<h3>3. Le cas Souheil, point de départ de la mobilisation</h3>
+<p>La pétition a été lancée par la famille de Souheil, 19 ans, tué par un tir de policier à Marseille en 2021. L'issue judiciaire de ce type de tir, scrutée de près par les familles comme par les syndicats de police, nourrit l'argumentaire des deux camps.</p>
+
+<h2>Les positions des ${candidatesCount} candidats à la présidentielle 2027</h2>
+<p>Sur la question <a href="/question-politique/presomption-legitime-defense-policiers">« Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre ? »</a> du <a href="/theme/police-justice-et-securite">Quizz du Berger</a>, les ${candidatesCount} candidats se répartissent en quatre familles.</p>
+
+<h3>Famille 1 — Soutien à la présomption, voire davantage</h3>
+<p>Ces candidats ou leurs partis ont voté pour le texte à l'Assemblée nationale, ou défendent une ligne sécuritaire au moins aussi ferme.</p>
+<ul>
+<li><a href="/candidat/eric-zemmour">Éric Zemmour</a> (Reconquête) — Sa ligne sécuritaire constante laisse penser qu'il jugerait la présomption insuffisante et plaiderait pour une irresponsabilité pénale plus large en cas de tir en service.</li>
+<li><a href="/candidat/marine-le-pen">Marine Le Pen</a> (RN) — Le Rassemblement national a voté pour le texte à l'Assemblée nationale.</li>
+<li><a href="/candidat/bruno-retailleau">Bruno Retailleau</a> (LR) — Chef des Républicains ; le groupe LR a voté pour le texte à l'Assemblée nationale.</li>
+<li><a href="/candidat/laurent-wauquiez">Laurent Wauquiez</a> (LR) — « On met sur un pied d'égalité des barbares avec des gendarmes qui nous protègent », a-t-il déclaré en défendant la présomption de légitime défense.</li>
+<li><a href="/candidat/xavier-bertrand">Xavier Bertrand</a> — Le groupe LR, dont il est issu, a voté pour le texte ; sa ligne sécuritaire est constante sur ce type de dossier.</li>
+<li><a href="/candidat/david-lisnard">David Lisnard</a> — Maire de Cannes engagé sur les questions d'ordre public, sa ligne laisse penser qu'il aurait soutenu le texte.</li>
+<li><a href="/candidat/gabriel-attal">Gabriel Attal</a> (Renaissance) — Son parti, pilier de la majorité gouvernementale, a voté pour le texte.</li>
+<li><a href="/candidat/francois-bayrou">François Bayrou</a> (MoDem) — Le MoDem, partenaire de la majorité gouvernementale qui a porté le texte, a très probablement voté pour.</li>
+<li><a href="/candidat/edouard-philippe">Édouard Philippe</a> (Horizons) — Horizons, membre de la majorité gouvernementale, a voté pour le texte.</li>
+<li><a href="/candidat/gerald-darmanin">Gérald Darmanin</a> — Ancien ministre de l'Intérieur puis de la Justice à la ligne sécuritaire affirmée, sa position laisse penser à un soutien à la présomption.</li>
+<li><a href="/candidat/nicolas-dupont-aignan">Nicolas Dupont-Aignan</a> (DLF) — Ligne souverainiste proche du RN sur les questions de sécurité, favorable à une présomption de légitime défense pour les forces de l'ordre.</li>
+</ul>
+
+<h3>Famille 2 — Position d'équilibre, sans renverser la charge de la preuve</h3>
+<p>Ces candidats n'ont pas de siège à l'Assemblée nationale et n'ont donc pas voté le texte ; leur ligne cherche un renforcement de la protection des policiers sans aller jusqu'à la présomption.</p>
+<ul>
+<li><a href="/candidat/bernard-cazeneuve">Bernard Cazeneuve</a> — Ancien ministre de l'Intérieur à la ligne sécuritaire mesurée, sa position laisse penser à un soutien à une meilleure protection juridique des policiers sans renversement de la charge de la preuve.</li>
+<li><a href="/candidat/francois-asselineau">François Asselineau</a> (UPR) — Peu engagé publiquement sur ce dossier précis, sa ligne souverainiste et conservatrice laisse penser à une position d'équilibre entre fermeté et respect du droit commun.</li>
+<li><a href="/candidat/patrick-sebastien">Patrick Sébastien</a> — Sa ligne populiste sur les questions de sécurité laisse penser à un soutien mesuré aux forces de l'ordre, sans position juridique tranchée sur le texte.</li>
+</ul>
+
+<h3>Famille 3 — Opposition à la présomption, retour au droit commun</h3>
+<p>Ces candidats ou leurs partis ont voté contre le texte au sein du bloc de gauche uni, en défendant l'application du droit commun aux forces de l'ordre comme à tout justiciable.</p>
+<ul>
+<li><a href="/candidat/jerome-guedj">Jérôme Guedj</a> (PS) — Le groupe socialiste a voté contre le texte à l'Assemblée nationale.</li>
+<li><a href="/candidat/francois-hollande">François Hollande</a> — Ligne proche du PS, dont le groupe a voté contre le texte.</li>
+<li><a href="/candidat/raphael-glucksmann">Raphaël Glucksmann</a> (Place Publique) — Sa famille politique s'est associée au vote contre le texte au sein du bloc de gauche.</li>
+<li><a href="/candidat/marine-tondelier">Marine Tondelier</a> (Les Écologistes) — Le groupe écologiste a voté contre le texte.</li>
+<li><a href="/candidat/delphine-batho">Delphine Batho</a> (Génération Écologie) — Ligne écologiste proche de celle des Écologistes, qui ont voté contre le texte.</li>
+<li><a href="/candidat/fabien-roussel">Fabien Roussel</a> (PCF) — Le groupe communiste a voté contre le texte.</li>
+<li><a href="/candidat/dominique-de-villepin">Dominique de Villepin</a> — Critique des dérives autoritaires de l'exécutif, sa ligne laisse penser à une opposition au renversement de la charge de la preuve.</li>
+</ul>
+
+<h3>Famille 4 — Abrogation, dénoncée comme un « permis de tuer »</h3>
+<p>Ces candidats jugent la présomption incompatible avec l'État de droit et réclament son abrogation.</p>
+<ul>
+<li><a href="/candidat/jean-luc-melenchon">Jean-Luc Mélenchon</a> (LFI) — « Si on gagne en 2027, on l'abrogera », a-t-il promis à propos du texte.</li>
+<li><a href="/candidat/francois-ruffin">François Ruffin</a> — Proche de la ligne LFI d'opposition frontale au texte.</li>
+<li><a href="/candidat/clementine-autain">Clémentine Autain</a> — Alignée sur la ligne LFI, y compris la dénonciation d'un « permis de tuer ».</li>
+<li><a href="/candidat/juan-branco">Juan Branco</a> — Avocat engagé dans la défense de victimes de violences policières, sa ligne professionnelle et politique est une opposition frontale au texte.</li>
+<li><a href="/candidat/nathalie-arthaud">Nathalie Arthaud</a> (LO) — Dénonce une loi qui renforce l'impunité policière au service de l'ordre établi.</li>
+</ul>
+
+<h2>Arguments pour et arguments contre la présomption de légitime défense</h2>
+<table>
+<tr><th>Arguments en faveur du texte</th><th>Arguments contre, ou réservés</th></tr>
+<tr><td>Protège des policiers et des gendarmes qui risquent leur vie à chaque intervention armée.</td><td>Renverse la charge de la preuve : à la victime ou à sa famille de prouver l'absence de légitime défense.</td></tr>
+<tr><td>Accélère des procédures judiciaires aujourd'hui longues et éprouvantes pour les agents mis en cause après un tir.</td><td>Amnesty International et la Ligue des droits de l'homme dénoncent un risque d'impunité, un « permis de tuer ».</td></tr>
+<tr><td>Voté par une majorité parlementaire nette : 313 voix contre 199.</td><td>Toute la gauche unie (LFI, PS, Écologistes, Liot) a voté contre.</td></tr>
+<tr><td>Un périmètre resserré aux policiers nationaux et aux gendarmes, la police municipale ayant été exclue du texte adopté.</td><td>Une pétition à plus de 730 000 signatures contre le texte a été classée sans débat par la commission des lois.</td></tr>
+<tr><td>Ses défenseurs y voient une réponse à une demande de longue date des syndicats de police.</td><td>Le cas de Souheil, tué par un tir de policier à Marseille en 2021, illustre pour les opposants les risques du dispositif.</td></tr>
+</table>
+
+<h2>Pour aller plus loin</h2>
+<p>La présomption de légitime défense s'inscrit dans un débat plus large sur la sécurité et la justice pénale. Sur le Quizz du Berger, les thèmes et questions qui touchent à ces sujets :</p>
+<ul>
+<li><a href="/theme/police-justice-et-securite">Police, Justice et Sécurité</a> — violences policières, doctrine pénale, nuisances du quotidien.</li>
+<li><a href="/question-politique/presomption-legitime-defense-policiers">Présomption de légitime défense</a> — la question complète et les réponses détaillées des ${candidatesCount} candidats.</li>
+</ul>
+
+<p><a href="/themes">→ Faire le quiz</a></p>
+`,
+    schema: {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: `Présomption de légitime défense pour les policiers : tout comprendre et les positions des ${candidatesCount} candidats à la présidentielle 2027`,
+      description:
+        "Loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée le 7 juillet 2026 : contenu du texte, pétition à 730 000 signatures classée sans suite, et positions détaillées des candidats à la présidentielle 2027.",
+      author: { '@type': 'Person', name: 'Arnaud Ambroselli' },
+      datePublished: '2026-08-03',
+      about: [
+        { '@type': 'Thing', name: 'Présomption de légitime défense' },
+        { '@type': 'Thing', name: "Forces de l'ordre" },
+        { '@type': 'Thing', name: 'Élection présidentielle française de 2027' },
+      ],
+    },
+  },
 ];

--- a/app-tanstack/src/pages/__snapshots__/Result.test.tsx.snap
+++ b/app-tanstack/src/pages/__snapshots__/Result.test.tsx.snap
@@ -69,13 +69,13 @@ exports[`Result (/result) > renders every candidate and locks their global perce
     ],
   },
   {
-    "percent": 56,
+    "percent": 55,
     "pseudos": [
       "Bernard Cazeneuve",
     ],
   },
   {
-    "percent": 51,
+    "percent": 50,
     "pseudos": [
       "François Asselineau",
     ],
@@ -87,7 +87,7 @@ exports[`Result (/result) > renders every candidate and locks their global perce
     ],
   },
   {
-    "percent": 48,
+    "percent": 47,
     "pseudos": [
       "François Bayrou",
     ],
@@ -99,7 +99,7 @@ exports[`Result (/result) > renders every candidate and locks their global perce
     ],
   },
   {
-    "percent": 39,
+    "percent": 38,
     "pseudos": [
       "Marine Le Pen",
     ],

--- a/app-tanstack/src/pages/__snapshots__/Themes.test.tsx.snap
+++ b/app-tanstack/src/pages/__snapshots__/Themes.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`Themes (/themes) > locks the visible theme list + per-theme question co
   {
     "fr": "Police, Justice et Sécurité",
     "id": "theme-2027-police",
-    "questionCount": 9,
+    "questionCount": 10,
   },
   {
     "fr": "Pouvoir d'achat et vie quotidienne",

--- a/app-tanstack/src/shared/candidates-answers.json
+++ b/app-tanstack/src/shared/candidates-answers.json
@@ -405,6 +405,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -1085,6 +1090,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 2
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -1769,6 +1779,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -2448,6 +2463,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -3133,6 +3153,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 2
@@ -3812,6 +3837,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 3
       },
       {
@@ -4497,6 +4527,11 @@
         "answerIndex": 1
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 2
@@ -5176,6 +5211,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -5861,6 +5901,11 @@
         "answerIndex": 1
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -6540,6 +6585,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 4
       },
       {
@@ -7225,6 +7275,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -7907,6 +7962,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -8586,6 +8646,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -9271,6 +9336,11 @@
         "answerIndex": 1
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -9950,6 +10020,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -10635,6 +10710,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 2
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -11314,6 +11394,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -11999,6 +12084,11 @@
         "answerIndex": 3
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -12678,6 +12768,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 3
       },
       {
@@ -13363,6 +13458,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -14045,6 +14145,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -14724,6 +14829,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 3
       },
       {
@@ -15409,6 +15519,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 0
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -16089,6 +16204,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 3
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -16978,6 +17098,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-union-europeenne-2027",
         "questionId": "question-2027-ue-01",
         "answerIndex": 1
@@ -17553,6 +17678,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
         "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 2
       },
       {
         "themeId": "theme-2027-gouvernance",

--- a/app-tanstack/src/shared/quizz-2027.json
+++ b/app-tanstack/src/shared/quizz-2027.json
@@ -1716,6 +1716,27 @@
           [0, 0, 1, 3, 5, 0],
           [0, 0, 0, 0, 0, 0]
         ]
+      },
+      {
+        "_id": "question-2027-pol-10",
+        "fr": "Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?",
+        "help": "https://www.assemblee-nationale.fr/dyn/actualites-accueil-hub/reconnaitre-une-presomption-de-legitime-defense-pour-les-forces-de-l-ordre-dans-l-exercice-de-leurs-fonctions-adoption-de-la-proposition-de-loi",
+        "answers": [
+          "Il faut aller plus loin qu'une présomption : une irresponsabilité pénale totale dès lors qu'un policier ou un gendarme utilise son arme en service",
+          "Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense",
+          "Un juste milieu : mieux protéger juridiquement et matériellement les forces de l'ordre, sans renverser la charge de la preuve",
+          "S'opposer à la présomption : le droit commun doit s'appliquer à tous, y compris aux forces de l'ordre, pour éviter tout risque d'impunité",
+          "Abroger ce texte, dénoncé comme un « permis de tuer » incompatible avec un État de droit",
+          "Ça ne m'intéresse pas / Je n'ai pas d'avis"
+        ],
+        "scores": [
+          [5, 3, 1, 0, 0, 0],
+          [3, 5, 3, 1, 0, 0],
+          [1, 3, 5, 3, 1, 0],
+          [0, 1, 3, 5, 3, 0],
+          [0, 0, 1, 3, 5, 0],
+          [0, 0, 0, 0, 0, 0]
+        ]
       }
     ]
   },

--- a/app-tanstack/src/utils/seo.ts
+++ b/app-tanstack/src/utils/seo.ts
@@ -231,6 +231,11 @@ const hotTopicSlugs: Record<string, { slug: string; seoTitle: string; seoDescrip
     seoTitle: 'Feux de forêt et sécurité civile : les positions des candidats à la présidentielle 2027',
     seoDescription: `Moyens des pompiers, flotte aérienne, adaptation des forêts au changement climatique : comparez les positions des ${candidatesCount} candidats à la présidentielle 2027.`,
   },
+  'question-2027-pol-10': {
+    slug: 'presomption-legitime-defense-policiers',
+    seoTitle: 'Présomption de légitime défense pour les policiers : les positions des candidats 2027',
+    seoDescription: `Loi sur la présomption de légitime défense pour les forces de l'ordre : comparez les positions des ${candidatesCount} candidats à la présidentielle 2027.`,
+  },
 };
 
 // Also auto-generate slugs for all remaining questions

--- a/expo/src/shared/candidates-answers.json
+++ b/expo/src/shared/candidates-answers.json
@@ -405,6 +405,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -1085,6 +1090,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
         "answerIndex": 0
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 2
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -1769,6 +1779,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -2448,6 +2463,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -3133,6 +3153,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 2
@@ -3812,6 +3837,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 3
       },
       {
@@ -4497,6 +4527,11 @@
         "answerIndex": 1
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 2
@@ -5176,6 +5211,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -5861,6 +5901,11 @@
         "answerIndex": 1
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -6540,6 +6585,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 4
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 4
       },
       {
@@ -7225,6 +7275,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -7907,6 +7962,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -8586,6 +8646,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -9271,6 +9336,11 @@
         "answerIndex": 1
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -9950,6 +10020,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -10635,6 +10710,11 @@
         "answerIndex": 2
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 2
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -11314,6 +11394,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 1
       },
       {
@@ -11999,6 +12084,11 @@
         "answerIndex": 3
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 3
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 3
@@ -12678,6 +12768,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 3
       },
       {
@@ -13363,6 +13458,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 4
@@ -14045,6 +14145,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 1
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -14724,6 +14829,11 @@
       {
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
+        "answerIndex": 3
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
         "answerIndex": 3
       },
       {
@@ -15409,6 +15519,11 @@
         "answerIndex": 0
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 0
+      },
+      {
         "themeId": "theme-2027-fiscal",
         "questionId": "question-2027-fisc-01",
         "answerIndex": 1
@@ -16089,6 +16204,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
         "answerIndex": 2
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 3
       },
       {
         "themeId": "theme-2027-fiscal",
@@ -16978,6 +17098,11 @@
         "answerIndex": 4
       },
       {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 4
+      },
+      {
         "themeId": "theme-union-europeenne-2027",
         "questionId": "question-2027-ue-01",
         "answerIndex": 1
@@ -17553,6 +17678,11 @@
         "themeId": "theme-2027-police",
         "questionId": "question-2027-pol-09",
         "answerIndex": 1
+      },
+      {
+        "themeId": "theme-2027-police",
+        "questionId": "question-2027-pol-10",
+        "answerIndex": 2
       },
       {
         "themeId": "theme-2027-gouvernance",

--- a/expo/src/shared/quizz-2027.json
+++ b/expo/src/shared/quizz-2027.json
@@ -4594,6 +4594,27 @@
           [0, 0, 1, 3, 5, 0],
           [0, 0, 0, 0, 0, 0]
         ]
+      },
+      {
+        "_id": "question-2027-pol-10",
+        "fr": "Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?",
+        "help": "https://www.assemblee-nationale.fr/dyn/actualites-accueil-hub/reconnaitre-une-presomption-de-legitime-defense-pour-les-forces-de-l-ordre-dans-l-exercice-de-leurs-fonctions-adoption-de-la-proposition-de-loi",
+        "answers": [
+          "Il faut aller plus loin qu'une présomption : une irresponsabilité pénale totale dès lors qu'un policier ou un gendarme utilise son arme en service",
+          "Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense",
+          "Un juste milieu : mieux protéger juridiquement et matériellement les forces de l'ordre, sans renverser la charge de la preuve",
+          "S'opposer à la présomption : le droit commun doit s'appliquer à tous, y compris aux forces de l'ordre, pour éviter tout risque d'impunité",
+          "Abroger ce texte, dénoncé comme un « permis de tuer » incompatible avec un État de droit",
+          "Ça ne m'intéresse pas / Je n'ai pas d'avis"
+        ],
+        "scores": [
+          [5, 3, 1, 0, 0, 0],
+          [3, 5, 3, 1, 0, 0],
+          [1, 3, 5, 3, 1, 0],
+          [0, 1, 3, 5, 3, 0],
+          [0, 0, 1, 3, 5, 0],
+          [0, 0, 0, 0, 0, 0]
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Why this topic

The Assemblée nationale adopted, on 7 July 2026 (313 vs 199), a law creating a "présomption de légitime défense" for police/gendarmes who use their weapon on duty — it reverses the burden of proof (prosecution must show the officer was *not* acting in self-defense, instead of the usual rule). A citizen petition against the text gathered 730,000+ signatures (well above the 500,000 threshold) and was still dismissed without a floor debate by the Assemblée's law committee on the night of 21–22 July 2026. This is genuinely hot (Assemblée nationale, Amnesty France, LDH, Reporterre, France Info, Basta all covered it within the last two weeks), politically substantive (a real security-vs-civil-liberties dividing line, government+LR+RN vs. the united left), and **not already covered** on the site — it's a distinct law from the "loi Ripost" article already published (rodéos/free parties/protoxyde d'azote), even though both are 2026 Interior-security texts.

It didn't map to any existing quiz question (`theme-2027-police` had violences policières, sécurité, doctrine pénale, terrorisme, formation policière, cannabis, mineurs délinquants, and the loi Ripost — nothing on police use-of-force legal presumption specifically), so I added a new question rather than force-fitting the article to an existing one.

**Topics considered and rejected:**
- **Taxe Zucman / retour de l'ISF** — old news, rejected by the Assemblée on 31 October 2025, budget 2026 already adopted 2 February 2026. No fresh hook this week, and the site already has a question (`question-2027-fisc-01`) covering it.
- **Villepin accusing Macron of "vassalisation"/submission to Trump** (Venezuela/Maduro) — from January 2026, outside the 7-day window.
- **Budget 2027 parliamentary calendar** — real and ongoing, but a slow procedural story (autumn debate calendar) with no single dividing-line event this week.
- **Nouvelle-Calédonie referendum** — significant but the exact status this week (postponed? held?) wasn't clearly confirmed by my sources; too much sourcing risk to write confidently in one session.
- **G7 Evian summit / Macron-Trump diplomacy** — already past, more international than a clean French-candidate dividing line for this quiz's format.

## Sources consulted

- ``[Assemblée nationale — adoption de la proposition de loi](https://www.assemblee-nationale.fr/dyn/actualites-accueil-hub/reconnaitre-une-presomption-de-legitime-defense-pour-les-forces-de-l-ordre-dans-l-exercice-de-leurs-fonctions-adoption-de-la-proposition-de-loi)``
- [Sénat — dossier législatif ppl25-866](https://www.senat.fr/dossier-legislatif/ppl25-866.html)
- [Amnesty France — « Permis de tuer »: ce qu'il faut savoir](https://www.amnesty.fr/reperes/loi-presomption-legitime-defense-de-la-police-ce-qu-il-faut-savoir/)
- [Planet.fr — loi adoptée à l'Assemblée (313 vs 199)](``https://www.planet.fr/politique-la-loi-sur-la-presomption-de-legitime-defense-pour-les-policiers-adoptee-a-lassemblee.2998015.29334.html``)
- [Reporterre — pétition à 730 000 signatures enterrée](``https://reporterre.net/Legitime-defense-des-policiers-la-petition-a-730-000-signatures-enterree-par-l-Assemblee``)
- [Basta! — RN, droite et macronistes enterrent la pétition](``https://basta.media/RN-droite-macronistes-enterrent-petition-contre-loi-presomption-de-legitime-defense-malgre-730000-signatures``)
- [France Info — l'Assemblée classe sans suite la pétition](``https://www.franceinfo.fr/faits-divers/police/l-assemblee-nationale-classe-sans-suite-la-petition-sur-la-presomption-d-usage-legitime-des-armes-a-feu-par-les-forces-de-l-ordre_8117588.html)``
- ``[France 3 Provence-Alpes — origine de la pétition (famille de Souheil, Marseille)](https://france3-regions.franceinfo.fr/provence-alpes-cote-d-azur/bouches-du-rhone/marseille/est-ce-qu-ils-vont-ignorer-700-000-personnes-lancee-par-un-marseillais-la-petition-contre-la-loi-sur-la-presomption-de-legitime-defense-des-policiers-arrive-a-l-assemblee-3389338.html)``
- [Plateforme des pétitions de l'Assemblée nationale — i-6334](https://petitions.assemblee-nationale.fr/initiatives/i-6334)
- [LDH — mobilisation contre la proposition de loi](``https://www.ldh-france.org/la-proposition-de-loi-sur-la-presomption-de-legitime-defense-pour-les-forces-de-lordre-ne-doit-pas-passer/``)
- [parlons-politique.fr — réactions (Wauquiez, Mélenchon)](``https://www.parlons-politique.fr/actualite-nationale/pourquoi-la-presomption-de-legitime-defense-fracture-encore-le-debat-sur-la-justice-et-la-protection-des-policiers_23925/)``

## New question added

`question-2027-pol-10` in `theme-2027-police` (Police, Justice et Sécurité), added identically to all 3 `quizz-2027.json` copies:

> **Que pensez-vous de la loi sur la présomption de légitime défense pour les forces de l'ordre, adoptée en juillet 2026 ?**
> 0. Il faut aller plus loin qu'une présomption : une irresponsabilité pénale totale dès lors qu'un policier ou un gendarme utilise son arme en service
> 1. Soutenir la loi telle qu'adoptée : elle protège des policiers qui risquent leur vie, c'est à l'accusation de prouver qu'il n'y a pas eu légitime défense
> 2. Un juste milieu : mieux protéger juridiquement et matériellement les forces de l'ordre, sans renverser la charge de la preuve
> 3. S'opposer à la présomption : le droit commun doit s'appliquer à tous, y compris aux forces de l'ordre, pour éviter tout risque d'impunité
> 4. Abroger ce texte, dénoncé comme un « permis de tuer » incompatible avec un État de droit
> 5. Ça ne m'intéresse pas / Je n'ai pas d'avis

Scores matrix (reused the proven pattern from `question-2027-pol-09`, square, 5 on diagonal):
```
[5, 3, 1, 0, 0, 0]
[3, 5, 3, 1, 0, 0]
[1, 3, 5, 3, 1, 0]
[0, 1, 3, 5, 3, 0]
[0, 0, 1, 3, 5, 0]
[0, 0, 0, 0, 0, 0]
```

Added to `hotTopicSlugs` in `seo.ts`: slug `presomption-legitime-defense-policiers`.

## Per-candidate positions — please veto any estimate that looks wrong

| Candidat | Réponse | Base | Raisonnement |
|---|---|---|---|
| Éric Zemmour | 0 – aller plus loin | **Estimé** | Ligne sécuritaire constante, plus dure que le RN sur le régalien |
| Marine Le Pen | 1 – soutenir | **Sourcé** (vote de groupe RN, 313 pour) | Le RN a voté pour le texte |
| Bruno Retailleau | 1 | **Sourcé** (vote de groupe LR) | Chef des Républicains, groupe LR a voté pour |
| Laurent Wauquiez | 1 | **Sourcé** (citation directe) | « On met sur un pied d'égalité des barbares avec des gendarmes qui nous protègent » |
| Xavier Bertrand | 1 | **Estimé** (aligné sur le vote du groupe LR) | Pas de citation individuelle trouvée |
| David Lisnard | 1 | **Estimé** | Maire de Cannes, profil sécuritaire proche LR |
| Gabriel Attal | 1 | **Sourcé** (vote de bloc gouvernemental) | Renaissance-MoDem-Horizons-LR ont voté pour |
| François Bayrou | 1 | **Estimé** (bloc gouvernemental) | Pas de citation individuelle trouvée |
| Édouard Philippe | 1 | **Sourcé** (vote de bloc) | Horizons, membre du bloc gouvernemental qui a voté pour |
| Gérald Darmanin | 1 | **Estimé** | Ancien ministre Intérieur puis Justice, ligne sécuritaire constante |
| Nicolas Dupont-Aignan | 1 | **Estimé** | Ligne souverainiste proche du RN sur la sécurité |
| Bernard Cazeneuve | 2 – juste milieu | **Estimé** | Ancien ministre de l'Intérieur, ligne sécuritaire mesurée |
| François Asselineau | 2 | **Estimé** (signal faible) | Peu engagé publiquement sur ce dossier précis |
| Patrick Sébastien | 2 | **Estimé** (signal faible) | Aucune position publique identifiée sur ce texte |
| Jérôme Guedj | 3 – s'opposer | **Sourcé** (vote de groupe PS) | Le groupe PS a voté contre |
| François Hollande | 3 | **Estimé** | Ligne proche du PS, dont le groupe a voté contre |
| Raphaël Glucksmann | 3 | **Estimé** | Eurodéputé (pas de vote à l'AN), aligné sur le bloc de gauche |
| Marine Tondelier | 3 | **Sourcé** (vote de groupe Écologistes) | Le groupe écologiste a voté contre |
| Delphine Batho | 3 | **Estimé** | Ligne proche des Écologistes |
| Fabien Roussel | 3 | **Sourcé** (vote de groupe PCF) | Le groupe communiste a voté contre |
| Dominique de Villepin | 3 | **Estimé** | Critique des dérives autoritaires, pas de citation sur ce texte précis |
| Jean-Luc Mélenchon | 4 – abroger | **Sourcé** (citation directe) | « Si on gagne en 2027, on l'abrogera » |
| François Ruffin | 4 | **Estimé** | Proche de la ligne LFI |
| Clémentine Autain | 4 | **Estimé** | Alignée sur la ligne LFI |
| Juan Branco | 4 | **Estimé** (fondé sur son profil) | Avocat engagé dans la défense de victimes de violences policières |
| Nathalie Arthaud | 4 | **Estimé** | Ligne trotskiste, critique constante de l'appareil d'État |

## Validation

- `cd app-tanstack && npm install && npm run typecheck` → clean.
- `npm test` → the 2 expected snapshot failures (per `claude.md`'s "Adding a question" rules): `theme-2027-police` questionCount 9→10 (only that theme), 4 candidates' global percentage shifted by exactly 1 point, pinned candidate still 100%. Accepted via `npx vitest run -u`, diffs reviewed and match expectations, `npm test` green after.
- All 3 `quizz-2027.json` copies verified content-identical (parsed JSON deep-equal); each of the 3 `candidates-answers.json` gained exactly one new answer entry per candidate (26/26).
- Article checked against `.claude/skills/no-ai-slop/SKILL.md` + `french.md` + `eval.md`: no banned words/phrases found, no colon-reveals, no summary-recap ending, prose em-dash count is 0 (all 32 em-dashes are the accepted `Nom — description` bullet/`Famille N — ...` header label pattern, same convention as the shipped `loi-ripost` article).

Article slug: `presomption-legitime-defense-policiers-france-candidats-2027`. New question page: `/question-politique/presomption-legitime-defense-policiers`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A5Av8fwyzqtyLn7Zh8sPBi)_